### PR TITLE
Fixing URLs of jupyter notebooks

### DIFF
--- a/collections/clms-lake-water-quality.yaml
+++ b/collections/clms-lake-water-quality.yaml
@@ -11,7 +11,7 @@ AdditionalInfoExternal:
     Title: Additional info 
     Path: clms-lake-water-quality/README.MD 
 Image: clms-lake-water-quality/clms-lake-water-quality.png
-Explore: "[Open Notebook](https://eurodatacube.com/marketplace/notebooks/contributions/EDC_xcube_generator_service.ipynb)"
+Explore: "[Open Notebook](https://eurodatacube.com/marketplace/notebooks/getting-started/EDC_xcube_generator_service.ipynb)"
 Resolution: 300m
 GeographicalCoverage: (180°W, 180°E, 90°N, 90°S)  
 TemporalAvailability: "['2018-01-01', '2020-12-21']"

--- a/collections/oceancolour-atl-chl-l4-nrt-observations-009-037.yaml
+++ b/collections/oceancolour-atl-chl-l4-nrt-observations-009-037.yaml
@@ -7,7 +7,7 @@ Description: |
   and after a few days superseded by Delayed Time (DT) files as soon as they are available to provide better quality.
 Documentation: "[Product information](https://resources.marine.copernicus.eu/?option=com_csw&view=details&product_id=OCEANCOLOUR_ATL_CHL_L4_NRT_OBSERVATIONS_009_037)"
 Image: oceancolour-atl-chl-l4-nrt-observations-009-037/oceancolour-atl-chl-l4-nrt-observations-009-037.png
-Explore: "[Open Notebook](https://eurodatacube.com/marketplace/notebooks/contributions/EDC_xcube_generator_service.ipynb)"
+Explore: "[Open Notebook](https://eurodatacube.com/marketplace/notebooks/getting-started/EDC_xcube_generator_service.ipynb)"
 Resolution: 1km
 GeographicalCoverage: |
  (46°W, 13°E, 20°N, 66°N)  

--- a/collections/reanalysis-era5-land-monthly-means.yaml
+++ b/collections/reanalysis-era5-land-monthly-means.yaml
@@ -15,7 +15,7 @@ AdditionalInfoExternal:
     Title: Additional info 
     Path: reanalysis-era5-land-monthly-means/README.MD 
 Image: reanalysis-era5-land-monthly-means/reanalysis-era5-land-monthly-means.png
-Explore: "[Open Notebook](https://eurodatacube.com/marketplace/notebooks/contributions/EDC_xcube_generator_service.ipynb)"
+Explore: "[Open Notebook](https://eurodatacube.com/marketplace/notebooks/getting-started/EDC_xcube_generator_service.ipynb)"
 Resolution: 0.1x0.1 degrees.
 GeographicalCoverage: (180°W, 180°E, 90°N, 90°S)  
 TemporalAvailability: January 1981 to 2-3 months before the present


### PR DESCRIPTION
Only changes in this PR are the fix of the URLs so they point ot the correct location of the jupyter example notebook. 