### PR TITLE
Update stac.hbs

### DIFF
--- a/_build/stac.hbs
+++ b/_build/stac.hbs
@@ -27,7 +27,7 @@
   "extent": {{{copyJson Extent}}},
   "links": [
     {
-      "href": "{{rootUrl}}/stac/{{Slug}}.json",
+      "href": "{{rootUrl}}stac/{{Slug}}.json",
       "rel": "self"
     },
 {{#each Configurations}}


### PR DESCRIPTION
remove slash from `"href": "{{rootUrl}}/stac/{{Slug}}.json",` 

As rootURL already ends with a slash we otherwise have two slashes in the URL which is a broken non existing URL.