### PR TITLE
Fix/l8 metadata

### DIFF
--- a/collections/landsat-8-l1.yaml
+++ b/collections/landsat-8-l1.yaml
@@ -142,6 +142,11 @@ CubeDimensions:
       - B10
       - B11
       - BQA
+      - QA_RADSAT
+      - VAA
+      - VZA
+      - SAA
+      - SZA
       - dataMask
 RegistryEntryAdded: "2018-04-17"
-RegistryEntryLastModified: "2021-08-18"
+RegistryEntryLastModified: "2021-09-27"

--- a/collections/landsat-8-l2.yaml
+++ b/collections/landsat-8-l2.yaml
@@ -133,7 +133,6 @@ CubeDimensions:
       - B06
       - B07
       - B10
-      - B11
       - BQA
       - QA_RADSAT
       - SR_QA_AEROSOL

--- a/collections/landsat-8-l2.yaml
+++ b/collections/landsat-8-l2.yaml
@@ -54,12 +54,6 @@ Configurations:
     upsampling: BICUBIC
     href: https://docs.sentinel-hub.com/api/latest/api/process/
     rel: processing-expression
-  - layer_name: True color - pansharpened
-    evalscript_url: "https://custom-scripts.sentinel-hub.com/landsat-8/true-color-pansharpened/script.js"
-    mosaicking_order: mostRecent
-    upsampling: BICUBIC
-    href: https://docs.sentinel-hub.com/api/latest/api/process/
-    rel: processing-expression
   - layer_name: False color
     evalscript_url: "https://custom-scripts.sentinel-hub.com/landsat-8/false-color/script.js"
     mosaicking_order: mostRecent
@@ -138,8 +132,6 @@ CubeDimensions:
       - B05
       - B06
       - B07
-      - B08
-      - B09
       - B10
       - B11
       - BQA
@@ -155,4 +147,4 @@ CubeDimensions:
       - ST_CDIST
       - dataMask
 RegistryEntryAdded: "2018-04-17"
-RegistryEntryLastModified: "2021-08-18"
+RegistryEntryLastModified: "2021-09-27"


### PR DESCRIPTION
Landsat - 8 had some missing bands in Level-1 and some non existing bands in Level-2. This PR adds respectively removes those bands (connected evalscripts). 