### PR TITLE
add Pricing keyword to details.hbs

### DIFF
--- a/_build/detail.hbs
+++ b/_build/detail.hbs
@@ -88,6 +88,11 @@
       {{#if CustomScripts}}
       <h4>Custom scripts</h4>
       {{{urlListRenderer CustomScripts}}}
+      {{/if}}  
+
+      {{#if Pricing}}
+      <h4>Pricing</h4>
+      <p>{{{md Pricing}}}</p>
       {{/if}}
 
       {{#if License}}


### PR DESCRIPTION
- this allows anything under `Pricing` keyword  to be displayed on the html page  
-  accepts anything in markdown format 