### PR TITLE
Extend collection metadata

### DIFF
--- a/collections/landsat-8-l1.yaml
+++ b/collections/landsat-8-l1.yaml
@@ -235,63 +235,143 @@ Summaries:
       description: Blue (482 nm)
       full_width_half_max: 0.06004
       name: B02
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - center_wavelength: 0.56141
       common_name: green
       description: Green (561.5 nm)
       full_width_half_max: 0.05733
       name: B03
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - center_wavelength: 0.65459
       common_name: red
       description: Red (654.5 nm)
       full_width_half_max: 0.03747
       name: B04
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - center_wavelength: 0.86467
       common_name: nir08
       description: Near Infrared (NIR) (865 nm)
       full_width_half_max: 0.02825
       name: B05
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - center_wavelength: 1.60886
       common_name: swir16
       description: Shortwave Infrared (SWIR) 1 (1608.5 nm)
       full_width_half_max: 0.08472
       name: B06
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - center_wavelength: 2.20073
       common_name: swir22
       description: Shortwave Infrared (SWIR) 2 (2200.5 nm)
       full_width_half_max: 0.18666
       name: B07
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - center_wavelength: 0.5895
       common_name: pan
       description: Panchromatic (589.5 nm)
       full_width_half_max: 0.1724
       name: B08
+      openeo:gsd:
+        value:
+          - 15
+          - 15
+        unit: m
     - center_wavelength: 1.37343
       common_name: cirrus
       description: Cirrus (1373.5 nm)
       full_width_half_max: 0.02039
       name: B09
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - center_wavelength: 10.895
       common_name: lwir11
       description: Thermal Infrared (TIRS) 1 (10895 nm)
       full_width_half_max: 0.8
       name: B10
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - center_wavelength: 12.005
       common_name: lwir12
       description: Thermal Infrared (TIRS) 2 (12005 nm)
       full_width_half_max: 1
       name: B11
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - description: Quality Assessment band (QA)
       name: BQA
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - description: Radiometric Saturation and Terrain Occlusion QA Band
       name: QA_RADSAT
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - description: View (sensor) Azimuth Angle
       name: VAA
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - description: View (sensor) Zenith Angle
       name: VZA
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - description: Sun Azimuth Angle
       name: SAA
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - description: Sun Zenith Angle
       name: SZA
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - description: The mask of data/no data pixels.
       name: dataMask
   eo:cloud_cover:

--- a/collections/landsat-8-l1.yaml
+++ b/collections/landsat-8-l1.yaml
@@ -165,10 +165,11 @@ Summaries:
       description: Ultra Blue (443 nm)
       full_width_half_max: 0.01598
       name: B01
-      openeo:gsd: 
-        - 30
-        - 30
-      openeo:gsd_unit: m
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - center_wavelength: 0.48204
       common_name: blue
       description: Blue (482 nm)

--- a/collections/landsat-8-l1.yaml
+++ b/collections/landsat-8-l1.yaml
@@ -116,12 +116,14 @@ CubeDimensions:
     extent:
       - -180
       - 180
+    reference_system: AUTO:42001
   y:
     type: spatial
     axis: y
     extent:
       - -85
       - 85
+    reference_system: AUTO:42001
   t:
     type: temporal
     extent:

--- a/collections/landsat-8-l1.yaml
+++ b/collections/landsat-8-l1.yaml
@@ -165,6 +165,10 @@ Summaries:
       description: Ultra Blue (443 nm)
       full_width_half_max: 0.01598
       name: B01
+      openeo:gsd: 
+        - 30
+        - 30
+      openeo:gsd_unit: m
     - center_wavelength: 0.48204
       common_name: blue
       description: Blue (482 nm)

--- a/collections/landsat-8-l1.yaml
+++ b/collections/landsat-8-l1.yaml
@@ -372,9 +372,6 @@ Summaries:
     - 'http://www.opengis.net/def/crs/EPSG/0/32759'
     - 'http://www.opengis.net/def/crs/EPSG/0/32760'
     - 'http://www.opengis.net/def/crs/SR-ORG/0/98739'
-  eo:gsd:
-    - 15
-    - 30
   platform:
     - landsat-8
 RegistryEntryAdded: "2018-04-17"

--- a/collections/landsat-8-l1.yaml
+++ b/collections/landsat-8-l1.yaml
@@ -116,14 +116,74 @@ CubeDimensions:
     extent:
       - -180
       - 180
-    reference_system: AUTO:42001
+    reference_system:
+      $schema: https://proj.org/schemas/v0.2/projjson.schema.json
+      type: GeodeticCRS
+      name: AUTO 42001 (Universal Transverse Mercator)
+      datum:
+        type: GeodeticReferenceFrame
+        name: World Geodetic System 1984
+        ellipsoid:
+          name: WGS 84
+          semi_major_axis: 6378137
+          inverse_flattening: 298.257223563
+      coordinate_system:
+        subtype: ellipsoidal
+        axis:
+          - name: Geodetic latitude
+            abbreviation: Lat
+            direction: north
+            unit: degree
+          - name: Geodetic longitude
+            abbreviation: Lon
+            direction: east
+            unit: degree
+      area: World
+      bbox:
+        south_latitude: -90
+        west_longitude: -180
+        north_latitude: 90
+        east_longitude: 180
+      id:
+        authority: OGC
+        code: Auto:42001
   y:
     type: spatial
     axis: y
     extent:
       - -85
       - 85
-    reference_system: AUTO:42001
+    reference_system:
+      $schema: https://proj.org/schemas/v0.2/projjson.schema.json
+      type: GeodeticCRS
+      name: AUTO 42001 (Universal Transverse Mercator)
+      datum:
+        type: GeodeticReferenceFrame
+        name: World Geodetic System 1984
+        ellipsoid:
+          name: WGS 84
+          semi_major_axis: 6378137
+          inverse_flattening: 298.257223563
+      coordinate_system:
+        subtype: ellipsoidal
+        axis:
+          - name: Geodetic latitude
+            abbreviation: Lat
+            direction: north
+            unit: degree
+          - name: Geodetic longitude
+            abbreviation: Lon
+            direction: east
+            unit: degree
+      area: World
+      bbox:
+        south_latitude: -90
+        west_longitude: -180
+        north_latitude: 90
+        east_longitude: 180
+      id:
+        authority: OGC
+        code: Auto:42001
   t:
     type: temporal
     extent:

--- a/collections/landsat-8-l2.yaml
+++ b/collections/landsat-8-l2.yaml
@@ -111,12 +111,74 @@ CubeDimensions:
     extent:
       - -180
       - 180
+    reference_system:
+      $schema: https://proj.org/schemas/v0.2/projjson.schema.json
+      type: GeodeticCRS
+      name: AUTO 42001 (Universal Transverse Mercator)
+      datum:
+        type: GeodeticReferenceFrame
+        name: World Geodetic System 1984
+        ellipsoid:
+          name: WGS 84
+          semi_major_axis: 6378137
+          inverse_flattening: 298.257223563
+      coordinate_system:
+        subtype: ellipsoidal
+        axis:
+          - name: Geodetic latitude
+            abbreviation: Lat
+            direction: north
+            unit: degree
+          - name: Geodetic longitude
+            abbreviation: Lon
+            direction: east
+            unit: degree
+      area: World
+      bbox:
+        south_latitude: -90
+        west_longitude: -180
+        north_latitude: 90
+        east_longitude: 180
+      id:
+        authority: OGC
+        code: Auto:42001
   y:
     type: spatial
     axis: y
     extent:
       - -85
       - 85
+    reference_system:
+      $schema: https://proj.org/schemas/v0.2/projjson.schema.json
+      type: GeodeticCRS
+      name: AUTO 42001 (Universal Transverse Mercator)
+      datum:
+        type: GeodeticReferenceFrame
+        name: World Geodetic System 1984
+        ellipsoid:
+          name: WGS 84
+          semi_major_axis: 6378137
+          inverse_flattening: 298.257223563
+      coordinate_system:
+        subtype: ellipsoidal
+        axis:
+          - name: Geodetic latitude
+            abbreviation: Lat
+            direction: north
+            unit: degree
+          - name: Geodetic longitude
+            abbreviation: Lon
+            direction: east
+            unit: degree
+      area: World
+      bbox:
+        south_latitude: -90
+        west_longitude: -180
+        north_latitude: 90
+        east_longitude: 180
+      id:
+        authority: OGC
+        code: Auto:42001
   t:
     type: temporal
     extent:
@@ -160,63 +222,158 @@ Summaries:
       description: Ultra Blue (443 nm)
       full_width_half_max: 0.01598
       name: B01
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - center_wavelength: 0.48204
       common_name: blue
       description: Blue (482 nm)
       full_width_half_max: 0.06004
       name: B02
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - center_wavelength: 0.56141
       common_name: green
       description: Green (561.5 nm)
       full_width_half_max: 0.05733
       name: B03
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - center_wavelength: 0.65459
       common_name: red
       description: Red (654.5 nm)
       full_width_half_max: 0.03747
       name: B04
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - center_wavelength: 0.86467
       common_name: nir08
       description: Near Infrared (NIR) (865 nm)
       full_width_half_max: 0.02825
       name: B05
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - center_wavelength: 1.60886
       common_name: swir16
       description: Shortwave Infrared (SWIR) 1 (1608.5 nm)
       full_width_half_max: 0.08472
       name: B06
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - center_wavelength: 2.20073
       common_name: swir22
       description: Shortwave Infrared (SWIR) 2 (2200.5 nm)
       full_width_half_max: 0.18666
       name: B07
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - center_wavelength: 10.895
       common_name: lwir11
       description: Thermal Infrared (TIRS) 1(10895 nm)
       full_width_half_max: 0.8
       name: B10
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - description: Quality Assessment band (QA)
       name: BQA
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - description: Radiometric Saturation and Terrain Occlusion QA Band
       name: QA_RADSAT
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - description: SR Aerosol QA
       name: SR_QA_AEROSOL
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - description: Surface Temperature QA
       name: ST_QA
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - description: Thermal band converted to radiance
       name: ST_TRAD
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - description: Upwelled Radiance
       name: ST_URAD
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - description: Downwelled Radiance
       name: ST_DRAD
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - description: Atmospheric Transmittance
       name: ST_ATRAN
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - description: Emissivity of Band 10 estimated from ASTER GED
       name: ST_EMIS
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - description: Emissivity standard deviation
       name: ST_EMSD
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - description: Pixel distance to cloud
       name: ST_CDIST
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - description: The mask of data/no data pixels.
       name: dataMask
   eo:cloud_cover:
@@ -364,8 +521,6 @@ Summaries:
     - 'http://www.opengis.net/def/crs/EPSG/0/32759'
     - 'http://www.opengis.net/def/crs/EPSG/0/32760'
     - 'http://www.opengis.net/def/crs/SR-ORG/0/98739'
-  eo:gsd:
-    - 30
   platform:
     - landsat-8
 RegistryEntryAdded: "2018-04-17"


### PR DESCRIPTION
- removed `eo:gsd`: it is not used by us and an in STAC deprecated (eo:gsd was moved into gsd (in item properties) (https://github.com/radiantearth/stac-spec/pull/784)
- `"reference_system"` added to cube:dimension as the native reference system the collection is saved in (following the reference_system description it was added as projjson: https://github.com/stac-extensions/datacube#horizontal-spatial-dimension-object, EPSG was not an option as there is no code for this AUTO42001 in EPSG)
- `openeo:gsd` to give the pixel resolution and the unit of the band
  - value: as array to cover cases where the pixel is not square
  - unit:  to cover cases where the given values would be in an other reference_system as specified in cube:dimension (or if not specified), in general it will have the same unit as used by the reference_system

Discussion on this changes in: https://github.com/openEOPlatform/architecture-docs/issues/128