### PR TITLE
Add/reference system and openeo:gsd nr2

### DIFF
--- a/collections/landsat-1-5-mss-l1.yaml
+++ b/collections/landsat-1-5-mss-l1.yaml
@@ -30,14 +30,14 @@ Tags:
   - open data
   - landsat
 License: "[License](https://www.usgs.gov/centers/eros/data-citation?qt-science_support_page_related_con=0#qt-science_support_page_related_con)"
-LicenseType: proprietary  
+LicenseType: proprietary
 LicenseUrl: https://www.usgs.gov/centers/eros/data-citation?qt-science_support_page_related_con=0#qt-science_support_page_related_con
 Resources:
   - Group: Sentinel Hub Resources
     EndPoint: services-uswest2.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
-    Type:  landsat-mss-l1 
+    Type: landsat-mss-l1 
     Notes: Global coverage from July 1972 to October 1992 and from June 2012 to January 2013
     Primary: true
   - Group: xcube Resources
@@ -90,18 +90,82 @@ CubeDimensions:
     extent:
       - -180
       - 180
+    reference_system:
+      $schema: https://proj.org/schemas/v0.2/projjson.schema.json
+      type: GeodeticCRS
+      name: AUTO 42001 (Universal Transverse Mercator)
+      datum:
+        type: GeodeticReferenceFrame
+        name: World Geodetic System 1984
+        ellipsoid:
+          name: WGS 84
+          semi_major_axis: 6378137
+          inverse_flattening: 298.257223563
+      coordinate_system:
+        subtype: ellipsoidal
+        axis:
+          - name: Geodetic latitude
+            abbreviation: Lat
+            direction: north
+            unit: degree
+          - name: Geodetic longitude
+            abbreviation: Lon
+            direction: east
+            unit: degree
+      area: World
+      bbox:
+        south_latitude: -90
+        west_longitude: -180
+        north_latitude: 90
+        east_longitude: 180
+      id:
+        authority: OGC
+        version: "1.3"
+        code: Auto42001
   y:
     type: spatial
     axis: y
     extent:
       - -85
       - 85
+    reference_system:
+      $schema: https://proj.org/schemas/v0.2/projjson.schema.json
+      type: GeodeticCRS
+      name: AUTO 42001 (Universal Transverse Mercator)
+      datum:
+        type: GeodeticReferenceFrame
+        name: World Geodetic System 1984
+        ellipsoid:
+          name: WGS 84
+          semi_major_axis: 6378137
+          inverse_flattening: 298.257223563
+      coordinate_system:
+        subtype: ellipsoidal
+        axis:
+          - name: Geodetic latitude
+            abbreviation: Lat
+            direction: north
+            unit: degree
+          - name: Geodetic longitude
+            abbreviation: Lon
+            direction: east
+            unit: degree
+      area: World
+      bbox:
+        south_latitude: -90
+        west_longitude: -180
+        north_latitude: 90
+        east_longitude: 180
+      id:
+        authority: OGC
+        version: "1.3"
+        code: Auto42001
   t:
     type: temporal
     extent:
       - '1972-07-01T00:00:00Z'
       - '2013-01-01T00:00:00Z'
-    step: P5D
+    step: P16D
   bands:
     type: bands
     values:
@@ -109,12 +173,223 @@ CubeDimensions:
       - B02
       - B03
       - B04
+      - BQA
       - QA_RADSAT
-      - VAA
-      - VZA
-      - SAA
-      - SZA
       - dataMask
 sci:citation: "Landsat 1-5 product courtesy of the U.S. Geological Survey, processed with Sentinel Hub"
+Summaries:
+  instruments:
+    - mss
+  sat:orbit_state:
+    - ascending
+    - descending
+  eo:bands:
+    - center_wavelength: 0.55
+      common_name: green
+      description: Green (500-600 nm)
+      full_width_half_max: 0.05
+      name: B01
+      openeo:gsd:
+        value:
+          - 60
+          - 60
+        unit: m
+    - center_wavelength: 0.65
+      common_name: red
+      description: Red (600-700 nm)
+      full_width_half_max: 0.05
+      name: B02
+      openeo:gsd:
+        value:
+          - 60
+          - 60
+        unit: m
+    - center_wavelength: 0.75
+      common_name: rededge
+      description: Ultra Red (700-800 nm)
+      full_width_half_max: 0.05
+      name: B03
+      openeo:gsd:
+        value:
+          - 60
+          - 60
+        unit: m
+    - center_wavelength: 0.95
+      common_name: nir09
+      description: Near Infrared (NIR) (800-1100 nm)
+      full_width_half_max: 0.15
+      name: B04
+      openeo:gsd:
+        value:
+          - 60
+          - 60
+        unit: m
+    - description: Quality Assessment band (QA)
+      name: BQA
+      openeo:gsd:
+        value:
+          - 60
+          - 60
+        unit: m
+    - description: Radiometric Saturation and Terrain Occlusion QA Band
+      name: QA_RADSAT
+      openeo:gsd:
+        value:
+          - 60
+          - 60
+        unit: m
+    - description: The mask of data/no data pixels.
+      name: dataMask
+  eo:cloud_cover:
+    - 0
+    - 100
+  crs:
+    - 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
+    - 'http://www.opengis.net/def/crs/EPSG/0/2154'
+    - 'http://www.opengis.net/def/crs/EPSG/0/2180'
+    - 'http://www.opengis.net/def/crs/EPSG/0/2193'
+    - 'http://www.opengis.net/def/crs/EPSG/0/3003'
+    - 'http://www.opengis.net/def/crs/EPSG/0/3004'
+    - 'http://www.opengis.net/def/crs/EPSG/0/3031'
+    - 'http://www.opengis.net/def/crs/EPSG/0/3035'
+    - 'http://www.opengis.net/def/crs/EPSG/0/4326'
+    - 'http://www.opengis.net/def/crs/EPSG/0/4346'
+    - 'http://www.opengis.net/def/crs/EPSG/0/4416'
+    - 'http://www.opengis.net/def/crs/EPSG/0/4765'
+    - 'http://www.opengis.net/def/crs/EPSG/0/4794'
+    - 'http://www.opengis.net/def/crs/EPSG/0/4844'
+    - 'http://www.opengis.net/def/crs/EPSG/0/4857'
+    - 'http://www.opengis.net/def/crs/EPSG/0/3912'
+    - 'http://www.opengis.net/def/crs/EPSG/0/3995'
+    - 'http://www.opengis.net/def/crs/EPSG/0/4026'
+    - 'http://www.opengis.net/def/crs/EPSG/0/5514'
+    - 'http://www.opengis.net/def/crs/EPSG/0/28992'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32601'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32602'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32603'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32604'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32605'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32606'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32607'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32608'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32609'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32610'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32611'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32612'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32613'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32614'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32615'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32616'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32617'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32618'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32619'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32620'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32621'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32622'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32623'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32624'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32625'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32626'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32627'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32628'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32629'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32630'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32631'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32632'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32633'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32634'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32635'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32636'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32637'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32638'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32639'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32640'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32641'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32642'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32643'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32644'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32645'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32646'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32647'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32648'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32649'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32650'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32651'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32652'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32653'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32654'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32655'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32656'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32657'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32658'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32659'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32660'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32701'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32702'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32703'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32704'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32705'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32706'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32707'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32708'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32709'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32710'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32711'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32712'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32713'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32714'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32715'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32716'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32717'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32718'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32719'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32720'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32721'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32722'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32723'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32724'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32725'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32726'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32727'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32728'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32729'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32730'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32731'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32732'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32733'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32734'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32735'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32736'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32737'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32738'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32739'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32740'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32741'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32742'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32743'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32744'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32745'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32746'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32746'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32748'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32749'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32750'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32751'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32752'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32753'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32754'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32755'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32756'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32757'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32758'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32759'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32760'
+    - 'http://www.opengis.net/def/crs/SR-ORG/0/98739'
+  platform:
+    - landsat-1
+    - landsat-2
+    - landsat-3
+    - landsat-4
+    - landsat-5
 RegistryEntryAdded: "2021-07-16"
 RegistryEntryLastModified: "2021-10-06"

--- a/collections/landsat-4-5-tm-l1.yaml
+++ b/collections/landsat-4-5-tm-l1.yaml
@@ -1,7 +1,7 @@
 Name: Landsat 4-5 TM L1
 Description: |
  The Landsat Thematic Mapper (TM) sensor was carried onboard Landsats 4 and 5. 
- TM collected data in 7 spectral bands; from  the blue, green, red, near-infrared, mid-infrared (2)  and  thermal infrared portions of the electromagnetic spectrum.
+ TM collected data in 7 spectral bands; from the blue, green, red, near-infrared, mid-infrared (2) and thermal infrared portions of the electromagnetic spectrum.
  Visit [USGS EROS Archive - Landsat Archives - Landsat 4-5 Thematic Mapper Collection 2 Level-1 Data](https://www.usgs.gov/centers/eros/science/usgs-eros-archive-landsat-archives-landsat-4-5-thematic-mapper-collection-2?qt-science_center_objects=0#qt-science_center_objects) webpage
  for more information.
 Documentation: "[here](https://docs.sentinel-hub.com/api/latest/data/landsat-tm/#available-bands-and-data)"
@@ -109,18 +109,82 @@ CubeDimensions:
     extent:
       - -180
       - 180
+    reference_system:
+      $schema: https://proj.org/schemas/v0.2/projjson.schema.json
+      type: GeodeticCRS
+      name: AUTO 42001 (Universal Transverse Mercator)
+      datum:
+        type: GeodeticReferenceFrame
+        name: World Geodetic System 1984
+        ellipsoid:
+          name: WGS 84
+          semi_major_axis: 6378137
+          inverse_flattening: 298.257223563
+      coordinate_system:
+        subtype: ellipsoidal
+        axis:
+          - name: Geodetic latitude
+            abbreviation: Lat
+            direction: north
+            unit: degree
+          - name: Geodetic longitude
+            abbreviation: Lon
+            direction: east
+            unit: degree
+      area: World
+      bbox:
+        south_latitude: -90
+        west_longitude: -180
+        north_latitude: 90
+        east_longitude: 180
+      id:
+        authority: OGC
+        version: "1.3"
+        code: Auto42001
   y:
     type: spatial
     axis: y
     extent:
       - -85
       - 85
+    reference_system:
+      $schema: https://proj.org/schemas/v0.2/projjson.schema.json
+      type: GeodeticCRS
+      name: AUTO 42001 (Universal Transverse Mercator)
+      datum:
+        type: GeodeticReferenceFrame
+        name: World Geodetic System 1984
+        ellipsoid:
+          name: WGS 84
+          semi_major_axis: 6378137
+          inverse_flattening: 298.257223563
+      coordinate_system:
+        subtype: ellipsoidal
+        axis:
+          - name: Geodetic latitude
+            abbreviation: Lat
+            direction: north
+            unit: degree
+          - name: Geodetic longitude
+            abbreviation: Lon
+            direction: east
+            unit: degree
+      area: World
+      bbox:
+        south_latitude: -90
+        west_longitude: -180
+        north_latitude: 90
+        east_longitude: 180
+      id:
+        authority: OGC
+        version: "1.3"
+        code: Auto42001
   t:
     type: temporal
     extent:
       - '1982-07-16T00:00:00Z'
       - '2012-05-04T00:00:00Z'
-    step: P5D
+    step: P16D
   bands:
     type: bands
     values:
@@ -150,37 +214,109 @@ Summaries:
       common_name: blue
       center_wavelength: 0.485
       full_width_half_max: 0.066
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - name: B02
       common_name: green
       center_wavelength: 0.569
       full_width_half_max: 0.081
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - name: B03
       common_name: red
       center_wavelength: 0.66
       full_width_half_max: 0.067
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - name: B04
       common_name: nir
       center_wavelength: 0.84
       full_width_half_max: 0.128
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - name: B05
       common_name: swir16
       center_wavelength: 1.676
       full_width_half_max: 0.217
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - name: B06
       common_name: lwir
       center_wavelength: 11.435
       full_width_half_max: 1.97
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - name: B07
       common_name: swir22
       center_wavelength: 2.223
       full_width_half_max: 0.252
-    - name: BQA
-    - name: QA_RADSAT
-    - name: VAA
-    - name: VZA
-    - name: SAA
-    - name: SZA
-    - name: data Mask
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: Quality Assessment band (QA)
+      name: BQA
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: Radiometric Saturation and Terrain Occlusion QA Band
+      name: QA_RADSAT
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: View (sensor) Azimuth Angle
+      name: VAA
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: View (sensor) Zenith Angle
+      name: VZA
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: Sun Azimuth Angle
+      name: SAA
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: Sun Zenith Angle
+      name: SZA
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: The mask of data/no data pixels.
+      name: dataMask
   eo:cloud_cover:
     - 0
     - 100
@@ -332,4 +468,4 @@ Summaries:
     - landsat-4
     - landsat-5
 RegistryEntryAdded: "2021-05-12"
-RegistryEntryLastModified: "2021-10-06"
+RegistryEntryLastModified: "2021-12-06"

--- a/collections/landsat-4-5-tm-l2.yaml
+++ b/collections/landsat-4-5-tm-l2.yaml
@@ -1,8 +1,8 @@
 Name: Landsat 4-5 TM L2
 Description: |
  The Landsat Thematic Mapper (TM) sensor was carried onboard Landsats 4 and 5. 
- TM collected data in 7 spectral bands; from  the blue, green, red, near-infrared, mid-infrared(2)  and  thermal infrared portions of the electromagnetic spectrum.
- L2 data  include Surface Reflectance and Surface Temperature scene-based products.
+ TM collected data in 7 spectral bands; from the blue, green, red, near-infrared, mid-infrared(2) and thermal infrared portions of the electromagnetic spectrum.
+ L2 data include Surface Reflectance and Surface Temperature scene-based products.
  Visit [USGS EROS Archive - Landsat Archives - Landsat 4-5 TM Collection 2 Level-2 Science Products](https://www.usgs.gov/centers/eros/science/usgs-eros-archive-landsat-archives-landsat-4-5-tm-collection-2-level-2-science?qt-science_center_objects=0#qt-science_center_objects)
  for  more information.
 Documentation: "[here](https://docs.sentinel-hub.com/api/latest/data/landsat-tm-l2/)"
@@ -14,7 +14,7 @@ TemporalAvailability: |
   Landsat 4 from July 1982 to December 1993  
   Landsat 5 from March 1984 to May 2012
 UpdateFrequency: Archived data
-BandInformation: Information about [bands and data](https://docs.sentinel-hub.com/api/latest/data/landsat-tm-l2/#available-bands-and-data)  
+BandInformation: Information about [bands and data](https://docs.sentinel-hub.com/api/latest/data/landsat-tm-l2/#available-bands-and-data)
 Contact: https://forum.sentinel-hub.com
 Provider: "[USGS](https://www.usgs.gov/)"
 ManagedBy: "[Sentinel Hub](https://www.sentinel-hub.com/)"
@@ -110,18 +110,82 @@ CubeDimensions:
     extent:
       - -180
       - 180
+    reference_system:
+      $schema: https://proj.org/schemas/v0.2/projjson.schema.json
+      type: GeodeticCRS
+      name: AUTO 42001 (Universal Transverse Mercator)
+      datum:
+        type: GeodeticReferenceFrame
+        name: World Geodetic System 1984
+        ellipsoid:
+          name: WGS 84
+          semi_major_axis: 6378137
+          inverse_flattening: 298.257223563
+      coordinate_system:
+        subtype: ellipsoidal
+        axis:
+          - name: Geodetic latitude
+            abbreviation: Lat
+            direction: north
+            unit: degree
+          - name: Geodetic longitude
+            abbreviation: Lon
+            direction: east
+            unit: degree
+      area: World
+      bbox:
+        south_latitude: -90
+        west_longitude: -180
+        north_latitude: 90
+        east_longitude: 180
+      id:
+        authority: OGC
+        version: "1.3"
+        code: Auto42001
   y:
     type: spatial
     axis: y
     extent:
       - -85
       - 85
+    reference_system:
+      $schema: https://proj.org/schemas/v0.2/projjson.schema.json
+      type: GeodeticCRS
+      name: AUTO 42001 (Universal Transverse Mercator)
+      datum:
+        type: GeodeticReferenceFrame
+        name: World Geodetic System 1984
+        ellipsoid:
+          name: WGS 84
+          semi_major_axis: 6378137
+          inverse_flattening: 298.257223563
+      coordinate_system:
+        subtype: ellipsoidal
+        axis:
+          - name: Geodetic latitude
+            abbreviation: Lat
+            direction: north
+            unit: degree
+          - name: Geodetic longitude
+            abbreviation: Lon
+            direction: east
+            unit: degree
+      area: World
+      bbox:
+        south_latitude: -90
+        west_longitude: -180
+        north_latitude: 90
+        east_longitude: 180
+      id:
+        authority: OGC
+        version: "1.3"
+        code: Auto42001
   t:
     type: temporal
     extent:
       - '1982-07-16T00:00:00Z'
       - '2012-05-04T00:00:00Z'
-    step: P5D
+    step: P16D
   bands:
     type: bands
     values:
@@ -134,6 +198,7 @@ CubeDimensions:
       - B07
       - BQA
       - QA_RADSAT
+      - ST_QA
       - ST_TRAD
       - ST_URAD
       - ST_DRAD
@@ -143,7 +208,6 @@ CubeDimensions:
       - ST_CDIST
       - SR_ATMOS_OPACITY
       - SR_CLOUD_QA
-      - ST_QA
       - dataMask
 sci:citation: "Landsat 4-5 product courtesy of the U.S. Geological Survey, processed with Sentinel Hub"
 Summaries:
@@ -157,43 +221,151 @@ Summaries:
       common_name: blue
       center_wavelength: 0.485
       full_width_half_max: 0.066
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - name: B02
       common_name: green
       center_wavelength: 0.569
       full_width_half_max: 0.081
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - name: B03
       common_name: red
       center_wavelength: 0.66
       full_width_half_max: 0.067
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - name: B04
       common_name: nir
       center_wavelength: 0.84
       full_width_half_max: 0.128
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - name: B05
       common_name: swir16
       center_wavelength: 1.676
       full_width_half_max: 0.217
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - name: B06
       common_name: lwir
       center_wavelength: 11.435
       full_width_half_max: 1.97
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
     - name: B07
       common_name: swir22
       center_wavelength: 2.223
       full_width_half_max: 0.252
-    - name: BQA
-    - name: QA_RADSAT
-    - name: ST_TRAD
-    - name: ST_URAD
-    - name: ST_DRAD
-    - name: ST_ATRAN
-    - name: ST_EMIS
-    - name: ST_EMSD
-    - name: ST_CDIST
-    - name: SR_ATMOS_OPACITY
-    - name: SR_CLOUD_QA
-    - name: ST_QA
-    - name: data Mask
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: Quality Assessment band (QA)
+      name: BQA
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: Radiometric Saturation and Terrain Occlusion QA Band
+      name: QA_RADSAT
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: Surface Temperature Uncertainty
+      name: ST_QA
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: Level-1 thermal band converted to thermal surface radiance
+      name: ST_TRAD
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: Upwelled Radiance
+      name: ST_URAD
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: Downwelled Radiance
+      name: ST_DRAD
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: Atmospheric Transmittance
+      name: ST_ATRAN
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: Emissivity estimated from ASTER GED
+      name: ST_EMIS
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: Emissivity standard deviation
+      name: ST_EMSD
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: Pixel distance to cloud
+      name: ST_CDIST
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: Internal SR Atmospheric Opacity
+      name: SR_ATMOS_OPACITY
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: Cloud Quality Assessment
+      name: SR_CLOUD_QA
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: The mask of data/no data pixels.
+      name: dataMask
   eo:cloud_cover:
     - 0
     - 100

--- a/collections/landsat-7-etm+-l1.yaml
+++ b/collections/landsat-7-etm+-l1.yaml
@@ -4,11 +4,11 @@ Description: |
  See [USGS EROS Archive](https://www.usgs.gov/centers/eros/science/usgs-eros-archive-landsat-archives-landsat-7-enhanced-thematic-mapper-plus?qt-science_center_objects=0#qt-science_center_objects) for more information. Landsat 7 Level-1 data provides Top of Atmosphere Reflectance and Top of the Atmosphere Brightness Temperature products. Level 1 data are available since April 1999. All scenes collected since May 30, 2003 have data gaps due to the Scan Line Corrector (SLC) failure.
 Documentation: "[here](https://docs.sentinel-hub.com/api/latest/data/landsat-etm/)"
 Image: landsat-7-etm+-l1/landsat-7-etm+-l1.png 
-Resolution: 30 m (15 m for the panchromatic band,  thermal band is re-sampled from 60 m)
+Resolution: 30 m (15 m for the panchromatic band, thermal band is re-sampled from 60 m)
 GeographicalCoverage: Global land
 TemporalAvailability: April 1999 - ongoing
 UpdateFrequency: Landsat data are added regularly,as soon as they are available in USGS AWS cloud 
-BandInformation: Information about [bands and data](https://docs.sentinel-hub.com/api/latest/data/landsat-etm/#available-bands-and-data)  
+BandInformation: Information about [bands and data](https://docs.sentinel-hub.com/api/latest/data/landsat-etm/#available-bands-and-data)
 Contact: https://forum.sentinel-hub.com/c/euro-data-cube/
 Provider: "[USGS](https://www.usgs.gov/)"
 ManagedBy: "[Sentinel Hub](https://www.sentinel-hub.com/)"
@@ -26,7 +26,7 @@ Tags:
   - open data
   - landsat
 License: "[License](https://www.usgs.gov/centers/eros/data-citation?qt-science_support_page_related_con=0#qt-science_support_page_related_con)"
-LicenseType: proprietary  
+LicenseType: proprietary
 LicenseUrl: https://www.usgs.gov/centers/eros/data-citation?qt-science_support_page_related_con=0#qt-science_support_page_related_con
 Resources:
   - Group: Sentinel Hub Resources
@@ -98,18 +98,82 @@ CubeDimensions:
     extent:
       - -180
       - 180
+    reference_system:
+      $schema: https://proj.org/schemas/v0.2/projjson.schema.json
+      type: GeodeticCRS
+      name: AUTO 42001 (Universal Transverse Mercator)
+      datum:
+        type: GeodeticReferenceFrame
+        name: World Geodetic System 1984
+        ellipsoid:
+          name: WGS 84
+          semi_major_axis: 6378137
+          inverse_flattening: 298.257223563
+      coordinate_system:
+        subtype: ellipsoidal
+        axis:
+          - name: Geodetic latitude
+            abbreviation: Lat
+            direction: north
+            unit: degree
+          - name: Geodetic longitude
+            abbreviation: Lon
+            direction: east
+            unit: degree
+      area: World
+      bbox:
+        south_latitude: -90
+        west_longitude: -180
+        north_latitude: 90
+        east_longitude: 180
+      id:
+        authority: OGC
+        version: "1.3"
+        code: Auto42001
   y:
     type: spatial
     axis: y
     extent:
       - -85
       - 85
+    reference_system:
+      $schema: https://proj.org/schemas/v0.2/projjson.schema.json
+      type: GeodeticCRS
+      name: AUTO 42001 (Universal Transverse Mercator)
+      datum:
+        type: GeodeticReferenceFrame
+        name: World Geodetic System 1984
+        ellipsoid:
+          name: WGS 84
+          semi_major_axis: 6378137
+          inverse_flattening: 298.257223563
+      coordinate_system:
+        subtype: ellipsoidal
+        axis:
+          - name: Geodetic latitude
+            abbreviation: Lat
+            direction: north
+            unit: degree
+          - name: Geodetic longitude
+            abbreviation: Lon
+            direction: east
+            unit: degree
+      area: World
+      bbox:
+        south_latitude: -90
+        west_longitude: -180
+        north_latitude: 90
+        east_longitude: 180
+      id:
+        authority: OGC
+        version: "1.3"
+        code: Auto42001
   t:
     type: temporal
     extent:
       - '1999-04-01T00:00:00Z'
       - null
-    step: P5D
+    step: P16D
   bands:
     type: bands
     values:
@@ -118,8 +182,10 @@ CubeDimensions:
       - B03
       - B04
       - B05
-      - B06_VCID_1, B06_VCID_2
+      - B06_VCID_1
+      - B06_VCID_2
       - B07
+      - B08
       - BQA
       - QA_RADSAT
       - VAA
@@ -128,5 +194,293 @@ CubeDimensions:
       - SZA
       - dataMask
 sci:citation: "Landsat 7 product courtesy of the U.S. Geological Survey, processed with Sentinel Hub"
+Summaries:
+  instruments:
+    - etm
+  sat:orbit_state:
+    - ascending
+    - descending
+  eo:bands:
+    - center_wavelength: 0.485
+      common_name: blue
+      description: Blue (450-520 nm)
+      full_width_half_max: 0.035
+      name: B01
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - center_wavelength: 0.56
+      common_name: green
+      description: 	Green (520-600 nm)
+      full_width_half_max: 0.04
+      name: B02
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - center_wavelength: 0.66
+      common_name: red
+      description: Red (630-690 nm)
+      full_width_half_max: 0.03
+      name: B03
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - center_wavelength: 0.835
+      common_name: nir
+      description: Near Infrared (NIR) (770-900 nm)
+      full_width_half_max: 0.065
+      name: B04
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - center_wavelength: 1.65
+      common_name: swir16
+      description: Shortwave Infrared (SWIR) 1 (1550-1750 nm)
+      full_width_half_max: 0.1
+      name: B05
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - center_wavelength: 11.45
+      common_name: lwir
+      description: Thermal Infrared VCID 1
+      full_width_half_max: 10.5
+      name: B06_VCID1
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - center_wavelength: 11.45
+      common_name: lwir
+      description: Thermal Infrared VCID 2
+      full_width_half_max: 10.5
+      name: B06_VCID2
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - center_wavelength: 2.22
+      common_name: swir22
+      description: Shortwave Infrared (SWIR) 2 (2090-2350 nm)	
+      full_width_half_max: 0.13
+      name: B07
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - center_wavelength: 0.71
+      common_name: pan
+      description: Panchromatic (520-900 nm)
+      full_width_half_max: 0.19
+      name: B08
+      openeo:gsd:
+        value:
+          - 15
+          - 15
+        unit: m
+    - description: Quality Assessment band (QA)
+      name: BQA
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: Radiometric Saturation and Terrain Occlusion QA Band
+      name: QA_RADSAT
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: View (sensor) Azimuth Angle
+      name: VAA
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: View (sensor) Zenith Angle
+      name: VZA
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: Sun Azimuth Angle
+      name: SAA
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: Sun Zenith Angle
+      name: SZA
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: The mask of data/no data pixels.
+      name: dataMask
+  eo:cloud_cover:
+    - 0
+    - 100
+  crs:
+    - 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
+    - 'http://www.opengis.net/def/crs/EPSG/0/2154'
+    - 'http://www.opengis.net/def/crs/EPSG/0/2180'
+    - 'http://www.opengis.net/def/crs/EPSG/0/2193'
+    - 'http://www.opengis.net/def/crs/EPSG/0/3003'
+    - 'http://www.opengis.net/def/crs/EPSG/0/3004'
+    - 'http://www.opengis.net/def/crs/EPSG/0/3031'
+    - 'http://www.opengis.net/def/crs/EPSG/0/3035'
+    - 'http://www.opengis.net/def/crs/EPSG/0/4326'
+    - 'http://www.opengis.net/def/crs/EPSG/0/4346'
+    - 'http://www.opengis.net/def/crs/EPSG/0/4416'
+    - 'http://www.opengis.net/def/crs/EPSG/0/4765'
+    - 'http://www.opengis.net/def/crs/EPSG/0/4794'
+    - 'http://www.opengis.net/def/crs/EPSG/0/4844'
+    - 'http://www.opengis.net/def/crs/EPSG/0/4857'
+    - 'http://www.opengis.net/def/crs/EPSG/0/3912'
+    - 'http://www.opengis.net/def/crs/EPSG/0/3995'
+    - 'http://www.opengis.net/def/crs/EPSG/0/4026'
+    - 'http://www.opengis.net/def/crs/EPSG/0/5514'
+    - 'http://www.opengis.net/def/crs/EPSG/0/28992'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32601'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32602'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32603'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32604'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32605'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32606'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32607'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32608'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32609'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32610'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32611'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32612'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32613'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32614'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32615'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32616'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32617'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32618'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32619'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32620'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32621'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32622'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32623'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32624'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32625'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32626'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32627'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32628'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32629'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32630'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32631'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32632'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32633'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32634'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32635'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32636'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32637'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32638'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32639'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32640'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32641'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32642'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32643'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32644'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32645'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32646'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32647'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32648'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32649'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32650'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32651'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32652'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32653'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32654'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32655'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32656'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32657'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32658'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32659'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32660'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32701'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32702'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32703'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32704'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32705'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32706'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32707'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32708'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32709'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32710'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32711'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32712'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32713'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32714'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32715'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32716'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32717'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32718'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32719'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32720'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32721'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32722'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32723'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32724'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32725'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32726'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32727'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32728'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32729'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32730'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32731'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32732'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32733'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32734'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32735'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32736'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32737'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32738'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32739'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32740'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32741'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32742'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32743'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32744'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32745'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32746'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32746'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32748'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32749'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32750'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32751'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32752'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32753'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32754'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32755'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32756'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32757'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32758'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32759'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32760'
+    - 'http://www.opengis.net/def/crs/SR-ORG/0/98739'
+  platform:
+    - landsat-7
 RegistryEntryAdded: "2021-07-16"
-RegistryEntryLastModified: "2021-10-06"
+RegistryEntryLastModified: "2021-12-06"

--- a/collections/landsat-7-etm+-l2.yaml
+++ b/collections/landsat-7-etm+-l2.yaml
@@ -8,7 +8,7 @@ Resolution: 30 m (thermal band is re-sampled from 60 m)
 GeographicalCoverage: Global land
 TemporalAvailability: April 1999 - ongoing
 UpdateFrequency: Landsat data are added regularly,as soon as they are available in USGS AWS cloud 
-BandInformation: Information about [bands and data](https://docs.sentinel-hub.com/api/latest/data/landsat-etm-l2/#available-bands-and-data)  
+BandInformation: Information about [bands and data](https://docs.sentinel-hub.com/api/latest/data/landsat-etm-l2/#available-bands-and-data)
 Contact: https://forum.sentinel-hub.com/c/euro-data-cube/
 Provider: "[USGS](https://www.usgs.gov/)"
 ManagedBy: "[Sentinel Hub](https://www.sentinel-hub.com/)"
@@ -26,7 +26,7 @@ Tags:
   - open data
   - landsat
 License: "[License](https://www.usgs.gov/centers/eros/data-citation?qt-science_support_page_related_con=0#qt-science_support_page_related_con)"
-LicenseType: proprietary  
+LicenseType: proprietary
 LicenseUrl: https://www.usgs.gov/centers/eros/data-citation?qt-science_support_page_related_con=0#qt-science_support_page_related_con
 Resources:
   - Group: Sentinel Hub Resources
@@ -104,18 +104,82 @@ CubeDimensions:
     extent:
       - -180
       - 180
+    reference_system:
+      $schema: https://proj.org/schemas/v0.2/projjson.schema.json
+      type: GeodeticCRS
+      name: AUTO 42001 (Universal Transverse Mercator)
+      datum:
+        type: GeodeticReferenceFrame
+        name: World Geodetic System 1984
+        ellipsoid:
+          name: WGS 84
+          semi_major_axis: 6378137
+          inverse_flattening: 298.257223563
+      coordinate_system:
+        subtype: ellipsoidal
+        axis:
+          - name: Geodetic latitude
+            abbreviation: Lat
+            direction: north
+            unit: degree
+          - name: Geodetic longitude
+            abbreviation: Lon
+            direction: east
+            unit: degree
+      area: World
+      bbox:
+        south_latitude: -90
+        west_longitude: -180
+        north_latitude: 90
+        east_longitude: 180
+      id:
+        authority: OGC
+        version: "1.3"
+        code: Auto42001
   y:
     type: spatial
     axis: y
     extent:
       - -85
       - 85
+    reference_system:
+      $schema: https://proj.org/schemas/v0.2/projjson.schema.json
+      type: GeodeticCRS
+      name: AUTO 42001 (Universal Transverse Mercator)
+      datum:
+        type: GeodeticReferenceFrame
+        name: World Geodetic System 1984
+        ellipsoid:
+          name: WGS 84
+          semi_major_axis: 6378137
+          inverse_flattening: 298.257223563
+      coordinate_system:
+        subtype: ellipsoidal
+        axis:
+          - name: Geodetic latitude
+            abbreviation: Lat
+            direction: north
+            unit: degree
+          - name: Geodetic longitude
+            abbreviation: Lon
+            direction: east
+            unit: degree
+      area: World
+      bbox:
+        south_latitude: -90
+        west_longitude: -180
+        north_latitude: 90
+        east_longitude: 180
+      id:
+        authority: OGC
+        version: "1.3"
+        code: Auto42001
   t:
     type: temporal
     extent:
       - '1999-04-01T00:00:00Z'
       - null
-    step: P5D
+    step: P16D
   bands:
     type: bands
     values:
@@ -140,5 +204,315 @@ CubeDimensions:
       - ST_QA
       - dataMask
 sci:citation: "Landsat 7 product courtesy of the U.S. Geological Survey, processed with Sentinel Hub"
+Summaries:
+  instruments:
+    - etm
+  sat:orbit_state:
+    - ascending
+    - descending
+  eo:bands:
+    - center_wavelength: 0.485
+      common_name: blue
+      description: Blue (450-520 nm)
+      full_width_half_max: 0.035
+      name: B01
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - center_wavelength: 0.56
+      common_name: green
+      description: 	Green (520-600 nm)
+      full_width_half_max: 0.04
+      name: B02
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - center_wavelength: 0.66
+      common_name: red
+      description: Red (630-690 nm)
+      full_width_half_max: 0.03
+      name: B03
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - center_wavelength: 0.835
+      common_name: nir
+      description: Near Infrared (NIR) (770-900 nm)
+      full_width_half_max: 0.065
+      name: B04
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - center_wavelength: 1.65
+      common_name: swir16
+      description: Shortwave Infrared (SWIR) 1 (1550-1750 nm)
+      full_width_half_max: 0.1
+      name: B05
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - center_wavelength: 11.45
+      common_name: lwir
+      description: Thermal Infrared (10400-12500 nm)
+      full_width_half_max: 10.5
+      name: B06
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - center_wavelength: 2.22
+      common_name: swir22
+      description: Shortwave Infrared (SWIR) 2 (2090-2350 nm)	
+      full_width_half_max: 0.13
+      name: B07
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: Quality Assessment band (QA)
+      name: BQA
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: Radiometric Saturation and Terrain Occlusion Quality Assessment Band
+      name: QA_RADSAT
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: Surface Temperature Uncertainty
+      name: ST_QA
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: Level-1 thermal band converted to thermal surface radiance
+      name: ST_TRAD
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: Upwelled Radiance
+      name: ST_URAD
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: Downwelled Radiance
+      name: ST_DRAD
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: Atmospheric Transmittance
+      name: ST_ATRAN
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: Emissivity estimated from ASTER GED
+      name: ST_EMIS
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: Emissivity standard deviation
+      name: ST_EMSD
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: Pixel distance to cloud
+      name: ST_CDIST
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: Internal SR Atmospheric Opacity
+      name: SR_ATMOS_OPACITY
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: Cloud Quality Assessment
+      name: SR_CLOUD_QA
+      openeo:gsd:
+        value:
+          - 30
+          - 30
+        unit: m
+    - description: The mask of data/no data pixels.
+      name: dataMask
+  eo:cloud_cover:
+    - 0
+    - 100
+  crs:
+    - 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
+    - 'http://www.opengis.net/def/crs/EPSG/0/2154'
+    - 'http://www.opengis.net/def/crs/EPSG/0/2180'
+    - 'http://www.opengis.net/def/crs/EPSG/0/2193'
+    - 'http://www.opengis.net/def/crs/EPSG/0/3003'
+    - 'http://www.opengis.net/def/crs/EPSG/0/3004'
+    - 'http://www.opengis.net/def/crs/EPSG/0/3031'
+    - 'http://www.opengis.net/def/crs/EPSG/0/3035'
+    - 'http://www.opengis.net/def/crs/EPSG/0/4326'
+    - 'http://www.opengis.net/def/crs/EPSG/0/4346'
+    - 'http://www.opengis.net/def/crs/EPSG/0/4416'
+    - 'http://www.opengis.net/def/crs/EPSG/0/4765'
+    - 'http://www.opengis.net/def/crs/EPSG/0/4794'
+    - 'http://www.opengis.net/def/crs/EPSG/0/4844'
+    - 'http://www.opengis.net/def/crs/EPSG/0/4857'
+    - 'http://www.opengis.net/def/crs/EPSG/0/3912'
+    - 'http://www.opengis.net/def/crs/EPSG/0/3995'
+    - 'http://www.opengis.net/def/crs/EPSG/0/4026'
+    - 'http://www.opengis.net/def/crs/EPSG/0/5514'
+    - 'http://www.opengis.net/def/crs/EPSG/0/28992'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32601'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32602'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32603'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32604'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32605'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32606'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32607'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32608'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32609'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32610'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32611'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32612'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32613'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32614'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32615'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32616'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32617'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32618'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32619'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32620'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32621'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32622'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32623'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32624'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32625'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32626'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32627'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32628'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32629'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32630'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32631'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32632'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32633'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32634'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32635'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32636'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32637'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32638'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32639'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32640'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32641'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32642'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32643'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32644'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32645'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32646'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32647'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32648'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32649'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32650'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32651'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32652'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32653'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32654'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32655'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32656'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32657'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32658'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32659'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32660'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32701'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32702'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32703'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32704'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32705'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32706'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32707'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32708'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32709'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32710'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32711'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32712'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32713'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32714'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32715'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32716'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32717'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32718'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32719'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32720'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32721'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32722'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32723'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32724'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32725'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32726'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32727'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32728'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32729'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32730'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32731'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32732'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32733'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32734'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32735'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32736'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32737'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32738'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32739'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32740'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32741'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32742'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32743'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32744'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32745'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32746'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32746'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32748'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32749'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32750'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32751'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32752'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32753'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32754'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32755'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32756'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32757'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32758'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32759'
+    - 'http://www.opengis.net/def/crs/EPSG/0/32760'
+    - 'http://www.opengis.net/def/crs/SR-ORG/0/98739'
+  platform:
+    - landsat-7
 RegistryEntryAdded: "2021-07-16"
-RegistryEntryLastModified: "2021-10-06"
+RegistryEntryLastModified: "2021-12-06"

--- a/collections/mapzen-dem.yaml
+++ b/collections/mapzen-dem.yaml
@@ -7,13 +7,13 @@ Description: |
   and other higher resolution sources for some parts of the world.
   Mapzen DEM provides bare-earth terrain heights and can also be used for the orthorectification of satellite imagery (e.g Sentinel 1).
 Documentation: "[here](https://docs.sentinel-hub.com/api/latest/data/dem/)"
-Image: mapzen-dem/mapzen-dem.png  
+Image: mapzen-dem/mapzen-dem.png
 EOBrowser: https://sentinelshare.page.link/wDL1
 Resolution: "varies per zoom level, location and data source [more info](https://github.com/tilezen/joerd/blob/master/docs/data-sources.md#what-is-the-ground-resolution)"
 GeographicalCoverage: Ocean and Land ([more info](https://github.com/tilezen/joerd/blob/master/docs/data-sources.md#footprints-database))
 TemporalAvailability: static [current version was built in 2017](https://github.com/tilezen/joerd/blob/master/docs/data-sources.md#data-updates)
 UpdateFrequency: depends on updates by Mapzen
-BandInformation: Information about [bands and data](https://docs.sentinel-hub.com/api/latest/data/dem/#available-bands-and-data)  
+BandInformation: Information about [bands and data](https://docs.sentinel-hub.com/api/latest/data/dem/#available-bands-and-data)
 Contact: https://forum.sentinel-hub.com/c/euro-data-cube/25
 Provider: "[Mapzen](https://www.mapzen.com/)"
 ManagedBy: "[Sentinel Hub](https://www.sentinel-hub.com/)"
@@ -50,7 +50,7 @@ Resources:
 CustomScripts:
     Title: Collection of DEM custom scripts
     URL: https://custom-scripts.sentinel-hub.com/#dem
-Configurations:     
+Configurations: 
   - layer_name: Color
     evalscript_url: "https://custom-scripts.sentinel-hub.com/dem/dem-color/script.js"
     mosaicking_order: mostRecent
@@ -97,22 +97,23 @@ CubeDimensions:
     extent:
       - -180
       - 180
+    reference_system: 4326
   y:
     type: spatial
     axis: y
     extent:
       - -85
       - 85
+    reference_system: 4326
   t:
     type: temporal
     extent:
       - null
       - null
-    step: P5D
   bands:
     type: bands
     values:
       - DEM
       - dataMask
 RegistryEntryAdded: "2018-04-17"
-RegistryEntryLastModified: "2021-08-18"
+RegistryEntryLastModified: "2021-12-09"

--- a/collections/modis.yaml
+++ b/collections/modis.yaml
@@ -112,12 +112,14 @@ CubeDimensions:
     extent:
       - -180
       - 180
+    reference_system: 4326
   y:
     type: spatial
     axis: y
     extent:
       - -85
       - 85
+    reference_system: 4326
   t:
     type: temporal
     extent:
@@ -143,29 +145,66 @@ Summaries:
       common_name: red
       center_wavelength: 0.645
       full_width_half_max: 0.05
+      openeo:gsd:
+        value:
+          - 500
+          - 500
+        unit: m
     - name: B02
       common_name: nir
       center_wavelength: 0.8585
       full_width_half_max: 0.035
+      openeo:gsd:
+        value:
+          - 500
+          - 500
+        unit: m
     - name: B03
       common_name: blue
       center_wavelength: 0.469
       full_width_half_max: 0.02
+      openeo:gsd:
+        value:
+          - 500
+          - 500
+        unit: m
     - name: B04
       common_name: green
       center_wavelength: 0.555
       full_width_half_max: 0.02
+      openeo:gsd:
+        value:
+          - 500
+          - 500
+        unit: m
     - name: B05
       center_wavelength: 1.24
       full_width_half_max: 0.02
+      openeo:gsd:
+        value:
+          - 500
+          - 500
+        unit: m
     - name: B06
       common_name: swir16
       center_wavelength: 1.64
       full_width_half_max: 0.024
+      openeo:gsd:
+        value:
+          - 500
+          - 500
+        unit: m
     - name: B07
       common_name: swir22
       center_wavelength: 2.13
       full_width_half_max: 0.05
+      openeo:gsd:
+        value:
+          - 500
+          - 500
+        unit: m
+    - description: The mask of data/no data pixels.
+      name: dataMask
   crs:
     - 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
     - 'http://www.opengis.net/def/crs/EPSG/0/2154'
@@ -314,4 +353,4 @@ Summaries:
     - Terra
     - Aqua
 RegistryEntryAdded: "2018-04-17"
-RegistryEntryLastModified: "2021-10-01"
+RegistryEntryLastModified: "2021-12-09"

--- a/collections/sentinel-1-grd.yaml
+++ b/collections/sentinel-1-grd.yaml
@@ -117,7 +117,7 @@ CubeDimensions:
     extent:
       - '2014-10-03T04:14:15Z'
       - null
-    step: P6D
+    step: null
   bands:
     type: bands
     values:

--- a/collections/sentinel-1-grd.yaml
+++ b/collections/sentinel-1-grd.yaml
@@ -45,7 +45,7 @@ Resources:
     Name: Sentinel Hub
     Role: processor
     Type: sentinel-1-grd
-    Notes: Global since January 2017
+    Notes: Global since October 2014
     Primary: true
   - EndPoint: eocloud.sentinel-hub.com
     Name: Sentinel Hub
@@ -91,13 +91,13 @@ Extent:
     bbox:
       -
         - -180
-        - -85
+        - -90
         - 180
-        - 85
+        - 90
   temporal:
     interval:
       -
-        - '2014-12-07T04:14:15Z'
+        - '2014-10-03T04:14:15Z'
         - null
 CubeDimensions:
   x:
@@ -110,14 +110,14 @@ CubeDimensions:
     type: spatial
     axis: y
     extent:
-      - -85
-      - 85
+      - -90
+      - 90
   t:
     type: temporal
     extent:
-      - '2014-12-07T04:14:15Z'
+      - '2014-10-03T04:14:15Z'
       - null
-    step: P5D
+    step: P6D
   bands:
     type: bands
     values:
@@ -143,7 +143,9 @@ Summaries:
   sar:resolution:
     - 10
     - 40
-  platform: Sentinel-1
+  platform: 
+    - sentinel-1a
+    - sentinel-1b
   sar:polarization:
     - SH
     - SV
@@ -309,4 +311,4 @@ Summaries:
     - 'http://www.opengis.net/def/crs/EPSG/0/32760'
     - 'http://www.opengis.net/def/crs/SR-ORG/0/98739'
 RegistryEntryAdded: "2018-04-17"
-RegistryEntryLastModified: "2021-10-06"
+RegistryEntryLastModified: "2021-11-30"

--- a/collections/sentinel-1-grd.yaml
+++ b/collections/sentinel-1-grd.yaml
@@ -3,8 +3,8 @@ Description:
   The [Sentinel - 1 radar imaging mission](https://sentinel.esa.int/web/sentinel/missions/sentinel-1)
   is composed of a constellation of two polar-orbiting satellites providing continous all-weather, day and night imagery for 
   Land and Maritime Monitoring. C-band synthentic aperture radar imaging has the advantage of operating at wavelenghts that are
-  not obstructed by clouds or lack of illumination  and therefore can acquire data during day or night under all weather conditions.
-  With  6 days repeat cycle on the entire world and daily acquistions of sea ice zones and Europe's major shipping routes,
+  not obstructed by clouds or lack of illumination and therefore can acquire data during day or night under all weather conditions.
+  With 6 days repeat cycle on the entire world and daily acquistions of sea ice zones and Europe's major shipping routes,
   Sentinel-1 ensures reliable data availability to support emergency services and applications requiring time series observations. 
   Sentinel-1 continues the retired ERS and ENVISAT missions. Level 1 GRD products are available since October 2014.
 Documentation: "[here](https://docs.sentinel-hub.com/api/latest/data/sentinel-1-grd/)"
@@ -15,7 +15,7 @@ Explore: "[Open Notebook](https://eurodatacube.com/marketplace/notebooks/contrib
 GeographicalCoverage: Land, coastal zones, shipping routes ([more info](https://sentinel.esa.int/web/sentinel/user-guides/sentinel-1-sar/revisit-and-coverage))
 TemporalAvailability: October 2014- ongoing
 UpdateFrequency: New Sentinel data are added regularly, usually within few hours after they are available on Copernicus Hub.
-BandInformation: Information about [bands and data](https://docs.sentinel-hub.com/api/latest/data/sentinel-1-grd/#available-bands-and-data)  
+BandInformation: Information about [bands and data](https://docs.sentinel-hub.com/api/latest/data/sentinel-1-grd/#available-bands-and-data)
 Contact: https://forum.sentinel-hub.com/c/euro-data-cube/25
 Provider: "[Copernicus](https://copernicus.eu/)"
 ManagedBy: "[Sentinel Hub](https://www.sentinel-hub.com/)"
@@ -55,7 +55,7 @@ Resources:
   - EndPoint: shservices.mundiwebservices.com
     Name: Sentinel Hub
     Role: processor
-    Type:  sentinel-1-grd
+    Type: sentinel-1-grd
     Notes: Rolling policy of 48 months for Europe , Rolling policy of 12 months for World
   - Group: xcube Resources
   - DatasetName: sentinel-1-grd 
@@ -142,6 +142,7 @@ Summaries:
     - descending
   sar:resolution:
     - 10
+    - 25
     - 40
   platform: 
     - sentinel-1a
@@ -311,4 +312,4 @@ Summaries:
     - 'http://www.opengis.net/def/crs/EPSG/0/32760'
     - 'http://www.opengis.net/def/crs/SR-ORG/0/98739'
 RegistryEntryAdded: "2018-04-17"
-RegistryEntryLastModified: "2021-11-30"
+RegistryEntryLastModified: "2021-12-09"

--- a/collections/sentinel-2-l1c.yaml
+++ b/collections/sentinel-2-l1c.yaml
@@ -132,12 +132,76 @@ CubeDimensions:
     extent:
       - -180
       - 180
+    reference_system:
+      $schema: https://proj.org/schemas/v0.2/projjson.schema.json
+      type: GeodeticCRS
+      name: AUTO 42001 (Universal Transverse Mercator)
+      datum:
+        type: GeodeticReferenceFrame
+        name: World Geodetic System 1984
+        ellipsoid:
+          name: WGS 84
+          semi_major_axis: 6378137
+          inverse_flattening: 298.257223563
+      coordinate_system:
+        subtype: ellipsoidal
+        axis:
+          - name: Geodetic latitude
+            abbreviation: Lat
+            direction: north
+            unit: degree
+          - name: Geodetic longitude
+            abbreviation: Lon
+            direction: east
+            unit: degree
+      area: World
+      bbox:
+        south_latitude: -90
+        west_longitude: -180
+        north_latitude: 90
+        east_longitude: 180
+      id:
+        authority: OGC
+        version: "1.3"
+        code: Auto42001
   y:
     type: spatial
     axis: y
     extent:
       - -56
       - 83
+    reference_system:
+      $schema: https://proj.org/schemas/v0.2/projjson.schema.json
+      type: GeodeticCRS
+      name: AUTO 42001 (Universal Transverse Mercator)
+      datum:
+        type: GeodeticReferenceFrame
+        name: World Geodetic System 1984
+        ellipsoid:
+          name: WGS 84
+          semi_major_axis: 6378137
+          inverse_flattening: 298.257223563
+      coordinate_system:
+        subtype: ellipsoidal
+        axis:
+          - name: Geodetic latitude
+            abbreviation: Lat
+            direction: north
+            unit: degree
+          - name: Geodetic longitude
+            abbreviation: Lon
+            direction: east
+            unit: degree
+      area: World
+      bbox:
+        south_latitude: -90
+        west_longitude: -180
+        north_latitude: 90
+        east_longitude: 180
+      id:
+        authority: OGC
+        version: "1.3"
+        code: Auto42001
   t:
     type: temporal
     extent:
@@ -175,51 +239,116 @@ Summaries:
       common_name: coastal
       center_wavelength: 0.4427
       full_width_half_max: 0.021
+      openeo:gsd:
+        value:
+          - 60
+          - 60
+        unit: m
     - name: B02
       common_name: blue
       center_wavelength: 0.4924
       full_width_half_max: 0.066
+      openeo:gsd:
+        value:
+          - 10
+          - 10
+        unit: m
     - name: B03
       common_name: green
       center_wavelength: 0.5598
       full_width_half_max: 0.036
+      openeo:gsd:
+        value:
+          - 10
+          - 10
+        unit: m
     - name: B04
       common_name: red
       center_wavelength: 0.6646
       full_width_half_max: 0.031
+      openeo:gsd:
+        value:
+          - 10
+          - 10
+        unit: m
     - name: B05
       center_wavelength: 0.7041
       full_width_half_max: 0.015
+      openeo:gsd:
+        value:
+          - 20
+          - 20
+        unit: m
     - name: B06
       center_wavelength: 0.7405
       full_width_half_max: 0.015
+      openeo:gsd:
+        value:
+          - 20
+          - 20
+        unit: m
     - name: B07
       center_wavelength: 0.7828
       full_width_half_max: 0.02
+      openeo:gsd:
+        value:
+          - 20
+          - 20
+        unit: m
     - name: B08
       common_name: nir
       center_wavelength: 0.8328
       full_width_half_max: 0.106
+      openeo:gsd:
+        value:
+          - 10
+          - 10
+        unit: m
     - name: B8A
       common_name: nir08
       center_wavelength: 0.8647
       full_width_half_max: 0.021
+      openeo:gsd:
+        value:
+          - 20
+          - 20
+        unit: m
     - name: B09
       common_name: nir09
       center_wavelength: 0.9451
       full_width_half_max: 0.02
+      openeo:gsd:
+        value:
+          - 60
+          - 60
+        unit: m
     - name: B10
       common_name: cirrus
       center_wavelength: 1.3735
       full_width_half_max: 0.031
+      openeo:gsd:
+        value:
+          - 60
+          - 60
+        unit: m
     - name: B11
       common_name: swir16
       center_wavelength: 1.6137
       full_width_half_max: 0.091
+      openeo:gsd:
+        value:
+          - 20
+          - 20
+        unit: m
     - name: B12
       common_name: swir22
       center_wavelength: 2.2024
       full_width_half_max: 0.175
+      openeo:gsd:
+        value:
+          - 20
+          - 20
+        unit: m
   constellation:
     - sentinel-2
   crs:
@@ -374,4 +503,4 @@ Summaries:
     - sentinel-2a
     - sentinel-2b
 RegistryEntryAdded: "2018-04-17"
-RegistryEntryLastModified: "2021-10-06"
+RegistryEntryLastModified: "2021-12-06"

--- a/collections/sentinel-2-l1c.yaml
+++ b/collections/sentinel-2-l1c.yaml
@@ -224,7 +224,6 @@ CubeDimensions:
       - B10
       - B11
       - B12
-      - SCL
       - CLP
       - CLM
       - sunAzimuthAngles
@@ -349,6 +348,50 @@ Summaries:
           - 20
           - 20
         unit: m
+    - description: Cloud probability, based on s2cloudless
+      name: CLP
+      openeo:gsd:
+        value:
+          - 160
+          - 160
+        unit: m
+    - description: Cloud masks
+      name: CLM
+      openeo:gsd:
+        value:
+          - 160
+          - 160
+        unit: m
+    - description: Sun azimuth angle
+      name: sunAzimuthAngles
+      openeo:gsd:
+        value:
+          - 5000
+          - 5000
+        unit: m
+    - description: Sun zenith angle
+      name: sunZenithAngles
+      openeo:gsd:
+        value:
+          - 5000
+          - 5000
+        unit: m
+    - description: Viewing azimuth angle
+      name: viewAzimuthMean
+      openeo:gsd:
+        value:
+          - 5000
+          - 5000
+        unit: m
+    - description: Viewing zenith angle
+      name: viewZenithMean
+      openeo:gsd:
+        value:
+          - 5000
+          - 5000
+        unit: m
+    - description: The mask of data/no data pixels.
+      name: dataMask
   constellation:
     - sentinel-2
   crs:
@@ -503,4 +546,4 @@ Summaries:
     - sentinel-2a
     - sentinel-2b
 RegistryEntryAdded: "2018-04-17"
-RegistryEntryLastModified: "2021-12-06"
+RegistryEntryLastModified: "2021-12-16"

--- a/collections/sentinel-2-l2a.yaml
+++ b/collections/sentinel-2-l2a.yaml
@@ -338,6 +338,78 @@ Summaries:
           - 20
           - 20
         unit: m
+    - description: Aerosol Optical Thickness map, based on Sen2Cor processor
+      name: AOT
+      openeo:gsd:
+        value:
+          - 10
+          - 10
+        unit: m
+    - description: Scene classification data, based on Sen2Cor processor, codelist
+      name: SCL
+      openeo:gsd:
+        value:
+          - 20
+          - 20
+        unit: m
+    - description: Snow probability, based on Sen2Cor processor
+      name: SNW
+      openeo:gsd:
+        value:
+          - 20
+          - 20
+        unit: m
+    - description: Cloud probability, based on Sen2Cor processor
+      name: CLD
+      openeo:gsd:
+        value:
+          - 20
+          - 20
+        unit: m
+    - description: Cloud probability, based on s2cloudless
+      name: CLP
+      openeo:gsd:
+        value:
+          - 160
+          - 160
+        unit: m
+    - description: Cloud masks
+      name: CLM
+      openeo:gsd:
+        value:
+          - 160
+          - 160
+        unit: m
+    - description: Sun azimuth angle
+      name: sunAzimuthAngles
+      openeo:gsd:
+        value:
+          - 5000
+          - 5000
+        unit: m
+    - description: Sun zenith angle
+      name: sunZenithAngles
+      openeo:gsd:
+        value:
+          - 5000
+          - 5000
+        unit: m
+    - description: Viewing azimuth angle
+      name: viewAzimuthMean
+      openeo:gsd:
+        value:
+          - 5000
+          - 5000
+        unit: m
+    - description: Viewing zenith angle
+      name: viewZenithMean
+      openeo:gsd:
+        value:
+          - 5000
+          - 5000
+        unit: m
+    - description: The mask of data/no data pixels.
+      name: dataMask
   constellation:
     - sentinel-2
   crs:
@@ -492,4 +564,4 @@ Summaries:
     - sentinel-2a
     - sentinel-2b
 RegistryEntryAdded: '2018-04-17'
-RegistryEntryLastModified: '2021-12-06'
+RegistryEntryLastModified: '2021-12-16'

--- a/collections/sentinel-2-l2a.yaml
+++ b/collections/sentinel-2-l2a.yaml
@@ -128,12 +128,76 @@ CubeDimensions:
     extent:
       - -180
       - 180
+    reference_system:
+      $schema: https://proj.org/schemas/v0.2/projjson.schema.json
+      type: GeodeticCRS
+      name: AUTO 42001 (Universal Transverse Mercator)
+      datum:
+        type: GeodeticReferenceFrame
+        name: World Geodetic System 1984
+        ellipsoid:
+          name: WGS 84
+          semi_major_axis: 6378137
+          inverse_flattening: 298.257223563
+      coordinate_system:
+        subtype: ellipsoidal
+        axis:
+          - name: Geodetic latitude
+            abbreviation: Lat
+            direction: north
+            unit: degree
+          - name: Geodetic longitude
+            abbreviation: Lon
+            direction: east
+            unit: degree
+      area: World
+      bbox:
+        south_latitude: -90
+        west_longitude: -180
+        north_latitude: 90
+        east_longitude: 180
+      id:
+        authority: OGC
+        version: "1.3"
+        code: Auto42001
   y:
     type: spatial
     axis: y
     extent:
       - -56
       - 83
+    reference_system:
+      $schema: https://proj.org/schemas/v0.2/projjson.schema.json
+      type: GeodeticCRS
+      name: AUTO 42001 (Universal Transverse Mercator)
+      datum:
+        type: GeodeticReferenceFrame
+        name: World Geodetic System 1984
+        ellipsoid:
+          name: WGS 84
+          semi_major_axis: 6378137
+          inverse_flattening: 298.257223563
+      coordinate_system:
+        subtype: ellipsoidal
+        axis:
+          - name: Geodetic latitude
+            abbreviation: Lat
+            direction: north
+            unit: degree
+          - name: Geodetic longitude
+            abbreviation: Lon
+            direction: east
+            unit: degree
+      area: World
+      bbox:
+        south_latitude: -90
+        west_longitude: -180
+        north_latitude: 90
+        east_longitude: 180
+      id:
+        authority: OGC
+        version: "1.3"
+        code: Auto42001
   t:
     type: temporal
     extent:
@@ -173,47 +237,107 @@ Summaries:
       common_name: coastal
       center_wavelength: 0.4427
       full_width_half_max: 0.021
+      openeo:gsd:
+        value:
+          - 60
+          - 60
+        unit: m
     - name: B02
       common_name: blue
       center_wavelength: 0.4924
       full_width_half_max: 0.066
+      openeo:gsd:
+        value:
+          - 10
+          - 10
+        unit: m
     - name: B03
       common_name: green
       center_wavelength: 0.5598
       full_width_half_max: 0.036
+      openeo:gsd:
+        value:
+          - 10
+          - 10
+        unit: m
     - name: B04
       common_name: red
       center_wavelength: 0.6646
       full_width_half_max: 0.031
+      openeo:gsd:
+        value:
+          - 10
+          - 10
+        unit: m
     - name: B05
       center_wavelength: 0.7041
       full_width_half_max: 0.015
+      openeo:gsd:
+        value:
+          - 20
+          - 20
+        unit: m
     - name: B06
       center_wavelength: 0.7405
       full_width_half_max: 0.015
+      openeo:gsd:
+        value:
+          - 20
+          - 20
+        unit: m
     - name: B07
       center_wavelength: 0.7828
       full_width_half_max: 0.02
+      openeo:gsd:
+        value:
+          - 20
+          - 20
+        unit: m
     - name: B08
       common_name: nir
       center_wavelength: 0.8328
       full_width_half_max: 0.106
+      openeo:gsd:
+        value:
+          - 10
+          - 10
+        unit: m
     - name: B8A
       common_name: nir08
       center_wavelength: 0.8647
       full_width_half_max: 0.021
+      openeo:gsd:
+        value:
+          - 20
+          - 20
+        unit: m
     - name: B09
       common_name: nir09
       center_wavelength: 0.9451
       full_width_half_max: 0.02
+      openeo:gsd:
+        value:
+          - 60
+          - 60
+        unit: m
     - name: B11
       common_name: swir16
       center_wavelength: 1.6137
       full_width_half_max: 0.091
+      openeo:gsd:
+        value:
+          - 20
+          - 20
+        unit: m
     - name: B12
       common_name: swir22
       center_wavelength: 2.2024
       full_width_half_max: 0.175
+      openeo:gsd:
+        value:
+          - 20
+          - 20
+        unit: m
   constellation:
     - sentinel-2
   crs:
@@ -368,4 +492,4 @@ Summaries:
     - sentinel-2a
     - sentinel-2b
 RegistryEntryAdded: '2018-04-17'
-RegistryEntryLastModified: '2021-10-06'
+RegistryEntryLastModified: '2021-12-06'

--- a/collections/sentinel-3-l1b-olci.yaml
+++ b/collections/sentinel-3-l1b-olci.yaml
@@ -115,7 +115,7 @@ CubeDimensions:
     extent:
       - '2016-04-17T11:33:13Z'
       - null
-    step: P5D
+    step: P2D
   bands:
     type: bands
     values:

--- a/collections/sentinel-3-l1b-olci.yaml
+++ b/collections/sentinel-3-l1b-olci.yaml
@@ -5,7 +5,7 @@ Description: |
  Sentinel -3 satellites make use of four main instruments on board; OLCI, SLSTR, SRAL and MWR, to measure sea surface topography, 
  sea and land surface temperature and ocean and land surface color.
  The medium resolution OLCI(Ocean and Land Colour Instrument) is the successor to ENVISAT's MERIS instrument. 
- Since its launch in 2016, OLCI acquires data of the entire globe atleast every 2 days, in 21 bands, from which information on  marine and terrestrial biomass can be derived. 
+ Since its launch in 2016, OLCI acquires data of the entire globe atleast every 2 days, in 21 bands, from which information on marine and terrestrial biomass can be derived. 
  OLCI also provides reliable information on the atmosphere, especially on the aerosols characterisation.
  Level 1B data provides calibrated, ortho-geolocated and spatially re-sampled Top Of Atmosphere (TOA) radiances for the 21 OLCI spectral bands.
 Documentation: "[here](https://docs.sentinel-hub.com/api/latest/data/sentinel-3-olci-l1b/)"
@@ -15,7 +15,7 @@ Resolution: 300m
 GeographicalCoverage: Ocean and Land ([more info](https://sentinel.esa.int/web/sentinel/user-guides/sentinel-3-olci/coverage))
 TemporalAvailability: April 2016 - ongoing
 UpdateFrequency: New Sentinel data are added regularly, usually within few hours after they are available on Copernicus Hub.
-BandInformation: Information about [bands and data](https://docs.sentinel-hub.com/api/latest/data/sentinel-3-olci-l1b/#available-bands-and-data)  
+BandInformation: Information about [bands and data](https://docs.sentinel-hub.com/api/latest/data/sentinel-3-olci-l1b/#available-bands-and-data)
 Contact: https://forum.sentinel-hub.com/c/euro-data-cube/25
 Provider: "[Copernicus](https://copernicus.eu/)"
 ManagedBy: "[Sentinel Hub](https://www.sentinel-hub.com/)"
@@ -102,12 +102,14 @@ CubeDimensions:
     extent:
       - -180
       - 180
+    reference_system: 4326
   y:
     type: spatial
     axis: y
     extent:
       - -85
       - 85
+    reference_system: 4326
   t:
     type: temporal
     extent:
@@ -138,6 +140,14 @@ CubeDimensions:
       - B19
       - B20
       - B21
+      - SAA
+      - SZA
+      - VAA
+      - VZA
+      - HUMIDITY
+      - SEA_LEVEL_PRESSURE
+      - TOTAL_COLUMN_OZONE
+      - TOTAL_COLUMN_WATER_VAPOUR
       - dataMask
 sci:citation: "Modified Copernicus Sentinel data [Year]/Sentinel Hub"
 Summaries:
@@ -147,66 +157,221 @@ Summaries:
     - name: B01
       center_wavelength: 0.4
       full_width_half_max: 0.015
+      openeo:gsd:
+        value:
+          - 300
+          - 300
+        unit: m
     - name: B02
       center_wavelength: 0.4125
       full_width_half_max: 0.01
+      openeo:gsd:
+        value:
+          - 300
+          - 300
+        unit: m
     - name: B03
       center_wavelength: 0.4425
       full_width_half_max: 0.01
+      openeo:gsd:
+        value:
+          - 300
+          - 300
+        unit: m
     - name: B04
       center_wavelength: 0.49
       full_width_half_max: 0.01
+      openeo:gsd:
+        value:
+          - 300
+          - 300
+        unit: m
     - name: B05
       center_wavelength: 0.51
       full_width_half_max: 0.01
+      openeo:gsd:
+        value:
+          - 300
+          - 300
+        unit: m
     - name: B06
       center_wavelength: 0.56
       full_width_half_max: 0.01
+      openeo:gsd:
+        value:
+          - 300
+          - 300
+        unit: m
     - name: B07
       center_wavelength: 0.62
       full_width_half_max: 0.01
+      openeo:gsd:
+        value:
+          - 300
+          - 300
+        unit: m
     - name: B08
       center_wavelength: 0.665
       full_width_half_max: 0.01
+      openeo:gsd:
+        value:
+          - 300
+          - 300
+        unit: m
     - name: B09
       center_wavelength: 0.67375
       full_width_half_max: 0.0075
+      openeo:gsd:
+        value:
+          - 300
+          - 300
+        unit: m
     - name: B10
       center_wavelength: 0.68125
       full_width_half_max: 0.0075
+      openeo:gsd:
+        value:
+          - 300
+          - 300
+        unit: m
     - name: B11
       center_wavelength: 0.70875
       full_width_half_max: 0.01
+      openeo:gsd:
+        value:
+          - 300
+          - 300
+        unit: m
     - name: B12
       center_wavelength: 0.75375
       full_width_half_max: 0.0075
+      openeo:gsd:
+        value:
+          - 300
+          - 300
+        unit: m
     - name: B13
       center_wavelength: 0.76125
       full_width_half_max: 0.0025
+      openeo:gsd:
+        value:
+          - 300
+          - 300
+        unit: m
     - name: B14
       center_wavelength: 0.764375
       full_width_half_max: 0.00375
+      openeo:gsd:
+        value:
+          - 300
+          - 300
+        unit: m
     - name: B15
       center_wavelength: 0.7675
       full_width_half_max: 0.0025
+      openeo:gsd:
+        value:
+          - 300
+          - 300
+        unit: m
     - name: B16
       center_wavelength: 0.77875
       full_width_half_max: 0.015
+      openeo:gsd:
+        value:
+          - 300
+          - 300
+        unit: m
     - name: B17
       center_wavelength: 0.865
       full_width_half_max: 0.02
+      openeo:gsd:
+        value:
+          - 300
+          - 300
+        unit: m
     - name: B18
       center_wavelength: 0.885
       full_width_half_max: 0.01
+      openeo:gsd:
+        value:
+          - 300
+          - 300
+        unit: m
     - name: B19
       center_wavelength: 0.9
       full_width_half_max: 0.01
+      openeo:gsd:
+        value:
+          - 300
+          - 300
+        unit: m
     - name: B20
       center_wavelength: 0.94
       full_width_half_max: 0.02
+      openeo:gsd:
+        value:
+          - 300
+          - 300
+        unit: m
     - name: B21
       center_wavelength: 1.02
       full_width_half_max: 0.04
+      openeo:gsd:
+        value:
+          - 300
+          - 300
+        unit: m
+    - name: SAA
+      openeo:gsd:
+        value:
+          - 19000
+          - 19000
+        unit: m
+    - name: SZA
+      openeo:gsd:
+        value:
+          - 19000
+          - 19000
+        unit: m
+    - name: VAA
+      openeo:gsd:
+        value:
+          - 19000
+          - 19000
+        unit: m
+    - name: VZA
+      openeo:gsd:
+        value:
+          - 19000
+          - 19000
+        unit: m
+    - name: HUMIDITY
+      openeo:gsd:
+        value:
+          - 19000
+          - 19000
+        unit: m
+    - name: SEA_LEVEL_PRESSURE
+      openeo:gsd:
+        value:
+          - 19000
+          - 19000
+        unit: m
+    - name: TOTAL_COLUMN_OZONE
+      openeo:gsd:
+        value:
+          - 19000
+          - 19000
+        unit: m
+    - name: TOTAL_COLUMN_WATER_VAPOUR
+      openeo:gsd:
+        value:
+          - 19000
+          - 19000
+        unit: m
+    - description: The mask of data/no data pixels.
+      name: dataMask
   crs:
     - 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
     - 'http://www.opengis.net/def/crs/EPSG/0/2154'
@@ -354,4 +519,4 @@ Summaries:
     - sentinel-3a
     - sentinel-3b
 RegistryEntryAdded: "2018-04-17"
-RegistryEntryLastModified: "2021-10-06"
+RegistryEntryLastModified: "2021-12-09"

--- a/collections/sentinel-3-l1b-slstr.yaml
+++ b/collections/sentinel-3-l1b-slstr.yaml
@@ -102,7 +102,7 @@ CubeDimensions:
     extent:
       - '2016-04-17T11:33:13Z'
       - null
-    step: P5D
+    step: P1D
   bands:
     type: bands
     values:

--- a/collections/sentinel-3-l1b-slstr.yaml
+++ b/collections/sentinel-3-l1b-slstr.yaml
@@ -16,7 +16,7 @@ Resolution: 500m and 1km
 GeographicalCoverage: Ocean and Land ([more info](https://sentinel.esa.int/web/sentinel/user-guides/sentinel-3-slstr/coverage))
 TemporalAvailability: April 2016 - ongoing
 UpdateFrequency: New Sentinel data are added regularly, usually within few hours after they are available on Copernicus Hub.
-BandInformation: Information about [bands and data](https://docs.sentinel-hub.com/api/latest/data/sentinel-3-slstr-l1b/#available-bands-and-data)  
+BandInformation: Information about [bands and data](https://docs.sentinel-hub.com/api/latest/data/sentinel-3-slstr-l1b/#available-bands-and-data)
 Contact: https://forum.sentinel-hub.com/c/euro-data-cube/25
 Provider: "[Copernicus](https://copernicus.eu/)"
 ManagedBy: "[Sentinel Hub](https://www.sentinel-hub.com/)"
@@ -89,12 +89,14 @@ CubeDimensions:
     extent:
       - -180
       - 180
+    reference_system: 4326
   y:
     type: spatial
     axis: y
     extent:
       - -85
       - 85
+    reference_system: 4326
   t:
     type: temporal
     extent:
@@ -127,36 +129,93 @@ Summaries:
     - name: S01
       center_wavelength: 0.55427
       full_width_half_max: 0.01926
+      openeo:gsd:
+        value:
+          - 500
+          - 500
+        unit: m
     - name: S02
       center_wavelength: 0.65947
       full_width_half_max: 0.01925
+      openeo:gsd:
+        value:
+          - 500
+          - 500
+        unit: m
     - name: S03
       center_wavelength: 0.868
       full_width_half_max: 0.0206
+      openeo:gsd:
+        value:
+          - 500
+          - 500
+        unit: m
     - name: S04
       center_wavelength: 1.3748
       full_width_half_max: 0.0208
+      openeo:gsd:
+        value:
+          - 500
+          - 500
+        unit: m
     - name: S05
       center_wavelength: 1.6134
       full_width_half_max: 0.06068
+      openeo:gsd:
+        value:
+          - 500
+          - 500
+        unit: m
     - name: S06
       center_wavelength: 2.2557
       full_width_half_max: 0.05015
+      openeo:gsd:
+        value:
+          - 500
+          - 500
+        unit: m
     - name: S07
       center_wavelength: 3.742
       full_width_half_max: 0.398
+      openeo:gsd:
+        value:
+          - 1000
+          - 1000
+        unit: m
     - name: S08
       center_wavelength: 10.854
       full_width_half_max: 0.776
+      openeo:gsd:
+        value:
+          - 1000
+          - 1000
+        unit: m
     - name: S09
       center_wavelength: 12.0225
       full_width_half_max: 0.905
+      openeo:gsd:
+        value:
+          - 1000
+          - 1000
+        unit: m
     - name: F01
       center_wavelength: 3.742
       full_width_half_max: 0.398
+      openeo:gsd:
+        value:
+          - 1000
+          - 1000
+        unit: m
     - name: F02
       center_wavelength: 10.854
       full_width_half_max: 0.776
+      openeo:gsd:
+        value:
+          - 1000
+          - 1000
+        unit: m
+    - description: The mask of data/no data pixels.
+      name: dataMask
   crs:
     - 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
     - 'http://www.opengis.net/def/crs/EPSG/0/2154'
@@ -306,4 +365,4 @@ Summaries:
     - sentinel-3a
     - sentinel-3b
 RegistryEntryAdded: "2018-04-17"
-RegistryEntryLastModified: "2021-10-06"
+RegistryEntryLastModified: "2021-12-09"

--- a/collections/sentinel-5p-l2-tropomi.yaml
+++ b/collections/sentinel-5p-l2-tropomi.yaml
@@ -153,7 +153,7 @@ CubeDimensions:
     extent:
       - '2018-04-30T00:18:50Z'
       - null
-    step: P5D
+    step: P1D
   bands:
     type: bands
     values:

--- a/collections/sentinel-5p-l2-tropomi.yaml
+++ b/collections/sentinel-5p-l2-tropomi.yaml
@@ -1,20 +1,20 @@
 Name: Sentinel-5P L2
 Description: |
  The Copernicus [Sentinel-5 Precursor mission](https://sentinels.copernicus.eu/web/sentinel/missions/sentinel-5p) dedicated to monitoring our atmosphere,
- consists of one satellite carrying the TROPOspheric Monitoring Instrument (TROPOMI) instrument.  Sentinel-5 Precursor mission aims to fill in
+ consists of one satellite carrying the TROPOspheric Monitoring Instrument (TROPOMI) instrument. Sentinel-5 Precursor mission aims to fill in
  global atmospheric data gap between the retired ENVISAT and AURA missions and the future Sentinel -5 mission.The main objective of TROPOMI is 
  provide daily global observations of key atmospheric constituents related to air quality, ozone layer and climate change monitoring and forecasting. 
  Level 2 data provide total columns of ozone, sulfur dioxide, nitrogen dioxide, carbon monoxide, formaldehyde, tropospheric columns of ozone, 
  vertical profiles of ozone and cloud & aerosol information. Level 2 data are available since April 2018.
- These measurements are used  for improving air quality forecasts as well as for monitoring the concentrations of atmospheric constituents.
+ These measurements are used for improving air quality forecasts as well as for monitoring the concentrations of atmospheric constituents.
 Documentation: "[here](https://docs.sentinel-hub.com/api/latest/data/sentinel-5p-l2/)"
-Image: sentinel-5p-l2-tropomi/sentinel-5p-l2-tropomi.png   
+Image: sentinel-5p-l2-tropomi/sentinel-5p-l2-tropomi.png
 EOBrowser: https://sentinelshare.page.link/GQwM
-Resolution:  5.5 km x 3.5 km since August 6th in 2019, 7.0 km x 3.5 km at beginning of mission [more info](https://sentinels.copernicus.eu/web/sentinel/data-products/-/asset_publisher/fp37fc19FN8F/content/sentinel-5-precursor-level-2-ozone)
+Resolution: 5.5 km x 3.5 km since August 6th in 2019, 7.0 km x 3.5 km at beginning of mission [more info](https://sentinels.copernicus.eu/web/sentinel/data-products/-/asset_publisher/fp37fc19FN8F/content/sentinel-5-precursor-level-2-ozone)
 GeographicalCoverage: Ocean and Land ([more info](https://sentinels.copernicus.eu/web/sentinel/missions/sentinel-5p/geographical-coverage))
 TemporalAvailability: April 2018 - ongoing
 UpdateFrequency: New Sentinel data are added regularly, usually within few hours after they are available on Copernicus Hub.
-BandInformation: Information about [bands and data](https://docs.sentinel-hub.com/api/latest/data/sentinel-5p-l2/#available-bands-and-data)  
+BandInformation: Information about [bands and data](https://docs.sentinel-hub.com/api/latest/data/sentinel-5p-l2/#available-bands-and-data)
 Contact: https://forum.sentinel-hub.com/c/euro-data-cube/25
 Provider: "[Copernicus](https://copernicus.eu/)"
 ManagedBy: "[Sentinel Hub](https://www.sentinel-hub.com/)"
@@ -43,7 +43,7 @@ Resources:
     Role: processor
     Type: sentinel-5p-l2
     Notes: Global since May 2018
-    Primary: true  
+    Primary: true
   - EndPoint: shservices.mundiwebservices.com
     Name: Sentinel Hub
     Role: processor
@@ -140,12 +140,14 @@ CubeDimensions:
     extent:
       - -180
       - 180
+    reference_system: 4326
   y:
     type: spatial
     axis: y
     extent:
       - -85
       - 85
+    reference_system: 4326
   t:
     type: temporal
     extent:
@@ -181,18 +183,85 @@ Summaries:
     - RPRO
   eo:bands:
     - name: CO
+      openeo:gsd:
+        value:
+          - 5500
+          - 3500
+        unit: m
     - name: HCHO
+      openeo:gsd:
+        value:
+          - 5500
+          - 3500
+        unit: m
     - name: NO2
+      openeo:gsd:
+        value:
+          - 5500
+          - 3500
+        unit: m
     - name: O3
+      openeo:gsd:
+        value:
+          - 5500
+          - 3500
+        unit: m
     - name: CH4
+      openeo:gsd:
+        value:
+          - 5500
+          - 3500
+        unit: m
     - name: AER_AI_340_380
+      openeo:gsd:
+        value:
+          - 5500
+          - 3500
+        unit: m
     - name: AER_AI_354_388
+      openeo:gsd:
+        value:
+          - 5500
+          - 3500
+        unit: m
     - name: CLOUD_BASE_PRESSURE
+      openeo:gsd:
+        value:
+          - 5500
+          - 3500
+        unit: m
     - name: CLOUD_TOP_PRESSURE
+      openeo:gsd:
+        value:
+          - 5500
+          - 3500
+        unit: m
     - name: CLOUD_BASE_HEIGHT
+      openeo:gsd:
+        value:
+          - 5500
+          - 3500
+        unit: m
     - name: CLOUD_TOP_HEIGHT
+      openeo:gsd:
+        value:
+          - 5500
+          - 3500
+        unit: m
     - name: CLOUD_OPTICAL_THICKNESS
+      openeo:gsd:
+        value:
+          - 5500
+          - 3500
+        unit: m
     - name: CLOUD_FRACTION
+      openeo:gsd:
+        value:
+          - 5500
+          - 3500
+        unit: m
+    - description: The mask of data/no data pixels.
+      name: dataMask
   crs:
     - 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
     - 'http://www.opengis.net/def/crs/EPSG/0/2154'
@@ -338,4 +407,4 @@ Summaries:
   eo:gsd: 7000
   platform: sentinel-5 precursor
 RegistryEntryAdded: "2018-04-17"
-RegistryEntryLastModified: "2021-10-06"
+RegistryEntryLastModified: "2021-12-09"


### PR DESCRIPTION
This PR adds two new keys (reference_system and openeo:gsd) to the collection metadata (STAC JSONs). Both were requested by Vito ([github issue](https://github.com/openEOPlatform/architecture-docs/issues/128)).

Information about the available bands and resolutions (openeo:gsd) taken from the SH documentation.

Information about the reference_system is:
- for S2 and Landsat collection from Matej Batic in [this MM post](https://chat.sinergise.com/sinergise/pl/6jfngrffibnfdrhdpsjh4myqjh)
- for others I put EPSG: 4326 as we don't have proper insight into this and can't really know ([comment Grega MM](https://chat.sinergise.com/sinergise/pl/d8gjnty4nb8fidepk1cmuq8hir))
  - ideally we still get the correct info here but for now having some default CRS specified at least allows Vito to continue with their task on "automatically add SH collections to openEOP"

This PR includes the most common SH collections.