### PR TITLE
Update eo:bands descriptions in S3 SLSTR, S5P, MODIS yaml files

### DIFF
--- a/collections/modis.yaml
+++ b/collections/modis.yaml
@@ -360,4 +360,4 @@ Summaries:
     - Terra
     - Aqua
 RegistryEntryAdded: "2018-04-17"
-RegistryEntryLastModified: "2021-12-09"
+RegistryEntryLastModified: "2022-01-20"

--- a/collections/modis.yaml
+++ b/collections/modis.yaml
@@ -141,7 +141,8 @@ Summaries:
   instruments:
     - modis
   eo:bands:
-    - name: B01
+    - description: Red (620 - 670 nm)
+      name: B01
       common_name: red
       center_wavelength: 0.645
       full_width_half_max: 0.05
@@ -150,7 +151,8 @@ Summaries:
           - 500
           - 500
         unit: m
-    - name: B02
+    - description: NIR (841 - 876 nm)
+      name: B02
       common_name: nir
       center_wavelength: 0.8585
       full_width_half_max: 0.035
@@ -159,7 +161,8 @@ Summaries:
           - 500
           - 500
         unit: m
-    - name: B03
+    - description: Blue (459 - 479 nm)
+      name: B03
       common_name: blue
       center_wavelength: 0.469
       full_width_half_max: 0.02
@@ -168,7 +171,8 @@ Summaries:
           - 500
           - 500
         unit: m
-    - name: B04
+    - description: Green (545 - 565 nm)
+      name: B04
       common_name: green
       center_wavelength: 0.555
       full_width_half_max: 0.02
@@ -177,7 +181,8 @@ Summaries:
           - 500
           - 500
         unit: m
-    - name: B05
+    - description: N/A (1230 - 1250 nm)
+      name: B05
       center_wavelength: 1.24
       full_width_half_max: 0.02
       openeo:gsd:
@@ -185,7 +190,8 @@ Summaries:
           - 500
           - 500
         unit: m
-    - name: B06
+    - description: SWIR16 (1628 - 1652 nm)
+      name: B06
       common_name: swir16
       center_wavelength: 1.64
       full_width_half_max: 0.024
@@ -194,7 +200,8 @@ Summaries:
           - 500
           - 500
         unit: m
-    - name: B07
+    - description: SWIR22 (2105 - 2155 nm)
+      name: B07
       common_name: swir22
       center_wavelength: 2.13
       full_width_half_max: 0.05

--- a/collections/sentinel-3-l1b-slstr.yaml
+++ b/collections/sentinel-3-l1b-slstr.yaml
@@ -376,4 +376,4 @@ Summaries:
     - sentinel-3a
     - sentinel-3b
 RegistryEntryAdded: "2018-04-17"
-RegistryEntryLastModified: "2021-12-09"
+RegistryEntryLastModified: "2022-01-20"

--- a/collections/sentinel-3-l1b-slstr.yaml
+++ b/collections/sentinel-3-l1b-slstr.yaml
@@ -126,7 +126,8 @@ Summaries:
     - ascending
     - descending
   eo:bands:
-    - name: S01
+    - description: Cloud screening, vegetation monitoring, aerosol
+      name: S01
       center_wavelength: 0.55427
       full_width_half_max: 0.01926
       openeo:gsd:
@@ -134,7 +135,8 @@ Summaries:
           - 500
           - 500
         unit: m
-    - name: S02
+    - description: NDVI, vegetation monitoring, aerosol
+      name: S02
       center_wavelength: 0.65947
       full_width_half_max: 0.01925
       openeo:gsd:
@@ -142,7 +144,8 @@ Summaries:
           - 500
           - 500
         unit: m
-    - name: S03
+    - description: NDVI, cloud flagging, pixel co-registration
+      name: S03
       center_wavelength: 0.868
       full_width_half_max: 0.0206
       openeo:gsd:
@@ -150,7 +153,8 @@ Summaries:
           - 500
           - 500
         unit: m
-    - name: S04
+    - description: Cirrus detection over land
+      name: S04
       center_wavelength: 1.3748
       full_width_half_max: 0.0208
       openeo:gsd:
@@ -158,7 +162,8 @@ Summaries:
           - 500
           - 500
         unit: m
-    - name: S05
+    - description: Cloud clearing, ice, snow, vegetation monitoring
+      name: S05
       center_wavelength: 1.6134
       full_width_half_max: 0.06068
       openeo:gsd:
@@ -166,7 +171,8 @@ Summaries:
           - 500
           - 500
         unit: m
-    - name: S06
+    - description: Vegetation state and cloud clearing
+      name: S06
       center_wavelength: 2.2557
       full_width_half_max: 0.05015
       openeo:gsd:
@@ -174,7 +180,8 @@ Summaries:
           - 500
           - 500
         unit: m
-    - name: S07
+    - description: SST, LST, Active fire
+      name: S07
       center_wavelength: 3.742
       full_width_half_max: 0.398
       openeo:gsd:
@@ -182,7 +189,8 @@ Summaries:
           - 1000
           - 1000
         unit: m
-    - name: S08
+    - description: SST, LST, Active fire
+      name: S08
       center_wavelength: 10.854
       full_width_half_max: 0.776
       openeo:gsd:
@@ -190,7 +198,8 @@ Summaries:
           - 1000
           - 1000
         unit: m
-    - name: S09
+    - description: SST, LST
+      name: S09
       center_wavelength: 12.0225
       full_width_half_max: 0.905
       openeo:gsd:
@@ -198,7 +207,8 @@ Summaries:
           - 1000
           - 1000
         unit: m
-    - name: F01
+    - description: Active fire
+      name: F01
       center_wavelength: 3.742
       full_width_half_max: 0.398
       openeo:gsd:
@@ -206,7 +216,8 @@ Summaries:
           - 1000
           - 1000
         unit: m
-    - name: F02
+    - description: Active fire
+      name: F02
       center_wavelength: 10.854
       full_width_half_max: 0.776
       openeo:gsd:

--- a/collections/sentinel-5p-l2-tropomi.yaml
+++ b/collections/sentinel-5p-l2-tropomi.yaml
@@ -182,79 +182,92 @@ Summaries:
     - OFFL
     - RPRO
   eo:bands:
-    - name: CO
+    - description: Carbon monoxide
+      name: CO
       openeo:gsd:
         value:
           - 5500
           - 3500
         unit: m
-    - name: HCHO
+    - description: Formaldehyde
+      name: HCHO
       openeo:gsd:
         value:
           - 5500
           - 3500
         unit: m
-    - name: NO2
+    - description: Nitrogen oxide
+      name: NO2
       openeo:gsd:
         value:
           - 5500
           - 3500
         unit: m
-    - name: O3
+    - description: Ozone
+      name: O3
       openeo:gsd:
         value:
           - 5500
           - 3500
         unit: m
-    - name: CH4
+    - description: Methane
+      name: CH4
       openeo:gsd:
         value:
           - 5500
           - 3500
         unit: m
-    - name: AER_AI_340_380
+    - description: UV (Ultraviolet) Aerosol Index calculated based on wavelengths of 340 nm and 380 nm
+      name: AER_AI_340_380
       openeo:gsd:
         value:
           - 5500
           - 3500
         unit: m
-    - name: AER_AI_354_388
+    - description: UV (Ultraviolet) Aerosol Index calculated based on wavelengths of 354 nm and 388 nm
+      name: AER_AI_354_388
       openeo:gsd:
         value:
           - 5500
           - 3500
         unit: m
-    - name: CLOUD_BASE_PRESSURE
+    - description: Cloud base pressure
+      name: CLOUD_BASE_PRESSURE
       openeo:gsd:
         value:
           - 5500
           - 3500
         unit: m
-    - name: CLOUD_TOP_PRESSURE
+    - description: Cloud top pressure
+      name: CLOUD_TOP_PRESSURE
       openeo:gsd:
         value:
           - 5500
           - 3500
         unit: m
-    - name: CLOUD_BASE_HEIGHT
+    - description: Cloud base height
+      name: CLOUD_BASE_HEIGHT
       openeo:gsd:
         value:
           - 5500
           - 3500
         unit: m
-    - name: CLOUD_TOP_HEIGHT
+    - description: Cloud top height
+      name: CLOUD_TOP_HEIGHT
       openeo:gsd:
         value:
           - 5500
           - 3500
         unit: m
-    - name: CLOUD_OPTICAL_THICKNESS
+    - description: Cloud optical thickness
+      name: CLOUD_OPTICAL_THICKNESS
       openeo:gsd:
         value:
           - 5500
           - 3500
         unit: m
-    - name: CLOUD_FRACTION
+    - description: Effective radiometric cloud fraction
+      name: CLOUD_FRACTION
       openeo:gsd:
         value:
           - 5500

--- a/collections/sentinel-5p-l2-tropomi.yaml
+++ b/collections/sentinel-5p-l2-tropomi.yaml
@@ -210,6 +210,13 @@ Summaries:
           - 5500
           - 3500
         unit: m
+    - description: Sulphur dioxide
+      name: SO2
+      openeo:gsd:
+        value:
+          - 5500
+          - 3500
+        unit: m
     - description: Methane
       name: CH4
       openeo:gsd:

--- a/collections/sentinel-5p-l2-tropomi.yaml
+++ b/collections/sentinel-5p-l2-tropomi.yaml
@@ -429,4 +429,4 @@ Summaries:
   platform: 
   - sentinel-5 precursor
 RegistryEntryAdded: "2018-04-17"
-RegistryEntryLastModified: "2021-12-09"
+RegistryEntryLastModified: "2022-01-20"


### PR DESCRIPTION
Descriptions are taken from
- `modis.yaml`: https://docs.sentinel-hub.com/api/latest/data/modis/mcd/#available-bands-and-data
- `sentinel-3-l1b-slstr.yaml`: https://docs.sentinel-hub.com/api/latest/data/sentinel-3-slstr-l1b/#available-bands-and-data
- `sentinel-5p-l2-tropomi.yaml`: https://docs.sentinel-hub.com/api/latest/data/sentinel-5p-l2/#available-bands-and-data

One band seemed to be missing in  `eo:bands` for `sentinel-5p-l2-tropomi.yaml` so I added it. 
It's Sulphur dioxide (SO2)) to the, but the git shows the changes in a funny way. It's between Ozone (O3) and Methane (CH4).

[internal issue](https://git.sinergise.com/team-6/openeo-platform/-/issues/30)