### PR TITLE
Add ProducedResults section that can be rendered as table or string

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,21 @@ BandInformation:
           Notes:
 Variables:
 Attributes:       
+ProducedResults:
+     or
+ProducedResults:
+  Table:
+      Columns:
+        - Name: Name
+          Title: Name
+        - Name: Description
+          Title: Description
+        - Name: Units
+          Title: Units          
+      Rows:
+        - Name: 
+          Description: 
+          Units:
 Contact:  
 Provider: 
 ManagedBy: 

--- a/_build/detail.hbs
+++ b/_build/detail.hbs
@@ -89,6 +89,11 @@
       <p>{{{tabelaricRenderer Attributes}}}</p>
       {{/if}}  
 
+      {{#if ProducedResults}}
+      <h4>Produced results</h4>
+      <p>{{{tabelaricRenderer ProducedResults}}}</p>
+      {{/if}}
+
       {{#if CustomScripts}}
       <h4>Custom scripts</h4>
       {{{urlListRenderer CustomScripts}}}

--- a/collections/sice.yaml
+++ b/collections/sice.yaml
@@ -33,7 +33,7 @@ Attributes:
       - Name: Projection
         Description: Target projection of the produced data. By default the results will be provided in EPSG:4326.
         Type: String
-AdditionalInfo:
+ProducedResults:
   Table:
     Columns:
       - Name: Name


### PR DESCRIPTION
Existing `AdditionalInfo` section is rendered as a string and we didn't want to change that, so we decided to add another section (`ProducedResults`) that is more fit for the data in `sice.yaml` file.

The `ProducedResults` is rendered as a table or as a string because of how the `tabelaricRenderer` function that renders tables is written (in `gulpfile.js`).

```javascript
  tabelaricRenderer: function (tabelaricData) {
    if (!tabelaricData) {
      return "";
    }

    if (!tabelaricData.Table) {
      return "<p>" + marked(tabelaricData, { renderer: renderer }) + "</p>"; // was a simple non-tabelaric string
    }
    
    ...
  },
```

I also added this new section to the  `CONTRIBUTING.md` (copied and modified `BandInformation`)