### PR TITLE
Fix / stac json files generation

### DIFF
--- a/_build/stac.hbs
+++ b/_build/stac.hbs
@@ -48,7 +48,9 @@
 {{/each}}
     {
       "href": "{{{escapeJson LicenseUrl}}}",
-      "rel": "license"
+      "rel": "license",
+      "title": "License",
+      "type": "text/html"
     }
   ],
   "cube:dimensions": {{{copyJson CubeDimensions}}},

--- a/collections/2mt_2020_monthly_average_from_cds.yaml
+++ b/collections/2mt_2020_monthly_average_from_cds.yaml
@@ -21,7 +21,7 @@ Tags:
 License: Full, open and free access, Copernicus license ([details](https://atmosphere.copernicus.eu/sites/default/files/repository/CAMS_data_license.pdf)).
 Resources:
  - Group: Sentinel Hub Resources
- - EndPoint: shservices.mundiwebservices.com
+ - EndPoint: https://shservices.mundiwebservices.com
    Name: Sentinel Hub
    Role: processor
    Type: byoc-e523ca12-43cf-467f-b4cf-506dfca7af91

--- a/collections/2mt_2020_monthly_average_from_cds.yaml
+++ b/collections/2mt_2020_monthly_average_from_cds.yaml
@@ -70,4 +70,4 @@ CubeDimensions:
     values:
      - AIR2MT
 RegistryEntryAdded: "2021-05-07"
-RegistryEntryLastModified: "2022-01-13"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/alos-2-palsar-2-scansar-for-agriculture.yaml
+++ b/collections/alos-2-palsar-2-scansar-for-agriculture.yaml
@@ -44,7 +44,7 @@ Tags:
 License: See [additional info](https://collections.eurodatacube.com/alos-2-palsar-2-scansar-for-agriculture/readme.html)
 Resources:
   - Group: Sentinel Hub Resources
-  - EndPoint: services.sentinel-hub.com
+  - EndPoint: https://services.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: byoc-7c90e9bb-0842-4f37-bb34-37b467eb5c95

--- a/collections/alos-2-palsar-2-scansar-for-agriculture.yaml
+++ b/collections/alos-2-palsar-2-scansar-for-agriculture.yaml
@@ -110,4 +110,4 @@ CubeDimensions:
       - HH
       - HV
 RegistryEntryAdded: "2021-06-09"
-RegistryEntryLastModified: "2021-09-24"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/alos-2-palsar-2-scansar-rice-fields-map.yaml
+++ b/collections/alos-2-palsar-2-scansar-rice-fields-map.yaml
@@ -108,4 +108,4 @@ CubeDimensions:
     values:
       - RF
 RegistryEntryAdded: "2021-06-09"
-RegistryEntryLastModified: "2021-09-24"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/alos-2-palsar-2-scansar-rice-fields-map.yaml
+++ b/collections/alos-2-palsar-2-scansar-rice-fields-map.yaml
@@ -43,7 +43,7 @@ Tags:
 License: See [additional info](https://collections.eurodatacube.com/alos-2-palsar-2-scansar-rice-fields-map/readme.html)
 Resources:
   - Group: Sentinel Hub Resources
-  - EndPoint: services.sentinel-hub.com
+  - EndPoint: https://services.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: byoc-4e6463e6-a328-4618-832c-fa03ed6852f1

--- a/collections/alos-2-palsar-2-stripmap-for-economy-sm1.yaml
+++ b/collections/alos-2-palsar-2-stripmap-for-economy-sm1.yaml
@@ -99,4 +99,4 @@ CubeDimensions:
     values:
       - HH
 RegistryEntryAdded: "2021-06-09"
-RegistryEntryLastModified: "2021-09-24"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/alos-2-palsar-2-stripmap-for-economy-sm1.yaml
+++ b/collections/alos-2-palsar-2-stripmap-for-economy-sm1.yaml
@@ -40,7 +40,7 @@ Tags:
 License: See [additional info](https://collections.eurodatacube.com/alos-2-palsar-2-stripmap-for-economy/readme.html)
 Resources:
   - Group: Sentinel Hub Resources
-  - EndPoint: services.sentinel-hub.com
+  - EndPoint: https://services.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: byoc-ebdc9854-64db-41bd-8918-2ca9f6f05525

--- a/collections/alos-2-palsar-2-stripmap-for-economy.yaml
+++ b/collections/alos-2-palsar-2-stripmap-for-economy.yaml
@@ -131,4 +131,4 @@ CubeDimensions:
       - HH
       - HV
 RegistryEntryAdded: "2021-06-09"
-RegistryEntryLastModified: "2021-09-24"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/alos-2-palsar-2-stripmap-for-economy.yaml
+++ b/collections/alos-2-palsar-2-stripmap-for-economy.yaml
@@ -50,7 +50,7 @@ Tags:
 License: See [additional info](https://collections.eurodatacube.com/alos-2-palsar-2-stripmap-for-economy/readme.html)
 Resources:
   - Group: Sentinel Hub Resources
-  - EndPoint: services.sentinel-hub.com
+  - EndPoint: https://services.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: byoc-5014c166-c13e-4bcf-b7cf-52d0312c54b8

--- a/collections/cams_glc_2017.yaml
+++ b/collections/cams_glc_2017.yaml
@@ -19,7 +19,7 @@ Tags:
 License: Full, open and free access, Copernicus license ([details](https://atmosphere.copernicus.eu/sites/default/files/repository/CAMS_data_license.pdf)).
 Resources:
  - Group: Sentinel Hub Resources
-   EndPoint: shservices.mundiwebservices.com
+   EndPoint: https://shservices.mundiwebservices.com
    Name: Sentinel Hub
    Role: processor   
    Type: byoc-b73ffbaf-92ff-4fd9-abf0-960c5fab5eaa

--- a/collections/cams_glc_2017.yaml
+++ b/collections/cams_glc_2017.yaml
@@ -70,4 +70,4 @@ CubeDimensions:
       - BLUE
       - GREEN
 RegistryEntryAdded: "2021-05-07"
-RegistryEntryLastModified: "2022-01-17"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/chl_water_quality_saturday.yaml
+++ b/collections/chl_water_quality_saturday.yaml
@@ -21,7 +21,7 @@ License: |
  [CC BY-NC-ND 3.0](https://creativecommons.org/licenses/by-nc-nd/3.0/), Credit: Provided by ISMAR Istituto di Scienze Marine at Consiglio Nazionale delle Ricerche
 Resources:
  - Group: Sentinel Hub Resources
- - EndPoint: shservices.mundiwebservices.com
+ - EndPoint: https://shservices.mundiwebservices.com
    Name: Sentinel Hub
    Role: processor
    Type: byoc-fa331cca-5be2-4736-8030-793af55c0ef1

--- a/collections/chl_water_quality_saturday.yaml
+++ b/collections/chl_water_quality_saturday.yaml
@@ -70,4 +70,4 @@ CubeDimensions:
     values:
       - chl
 RegistryEntryAdded: "2021-05-07"
-RegistryEntryLastModified: "2021-09-22"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/copernicus-dem.yaml
+++ b/collections/copernicus-dem.yaml
@@ -36,7 +36,7 @@ LicenseType: proprietary
 LicenseUrl: https://spacedata.copernicus.eu/documents/20126/0/CSCDA_ESA_Mission-specific+Annex+%281%29.pdf/83b44c0a-244a-7ba3-b00c-b578a34e88a7?t=1604070311399
 Resources:
   - Group: Sentinel Hub Resources
-    EndPoint: services.sentinel-hub.com
+    EndPoint: https://services.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: dem

--- a/collections/copernicus-dem.yaml
+++ b/collections/copernicus-dem.yaml
@@ -127,4 +127,4 @@ Summaries:
     - description: The mask of data/no data pixels.
       name: dataMask
 RegistryEntryAdded: "2020-11-30"
-RegistryEntryLastModified: "2022-01-27"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/corine-land-cover-accounting-layers.yaml
+++ b/collections/corine-land-cover-accounting-layers.yaml
@@ -40,7 +40,7 @@ LicenseType: proprietary
 LicenseUrl: https://www.eea.europa.eu/legal/copyright
 Resources:
   - Group: Sentinel Hub Resources
-    EndPoint: creodias.sentinel-hub.com
+    EndPoint: https://creodias.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: byoc-4c5441a6-6040-4dc4-a392-c1317bbd1031

--- a/collections/corine-land-cover-accounting-layers.yaml
+++ b/collections/corine-land-cover-accounting-layers.yaml
@@ -93,4 +93,4 @@ CubeDimensions:
       - CLC_ACC
       - dataMask
 RegistryEntryAdded: "2021-10-20"
-RegistryEntryLastModified: "2022-01-13"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/corine-land-cover.yaml
+++ b/collections/corine-land-cover.yaml
@@ -33,7 +33,7 @@ LicenseType: proprietary
 LicenseUrl: https://land.copernicus.eu/terms-of-use
 Resources:
   - Group: Sentinel Hub Resources
-    EndPoint: creodias.sentinel-hub.com
+    EndPoint: https://creodias.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: byoc-cbdba844-f86d-41dc-95ad-b3f7f12535e9

--- a/collections/corine-land-cover.yaml
+++ b/collections/corine-land-cover.yaml
@@ -87,4 +87,4 @@ CubeDimensions:
       - CLC
       - dataMask
 RegistryEntryAdded: "2021-03-21"
-RegistryEntryLastModified: "2022-01-13"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/e12c_motorway.yaml
+++ b/collections/e12c_motorway.yaml
@@ -69,4 +69,4 @@ CubeDimensions:
     values:
       - MotorwayActivity
 RegistryEntryAdded: "2021-05-07"
-RegistryEntryLastModified: "2021-09-22"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/e12c_motorway.yaml
+++ b/collections/e12c_motorway.yaml
@@ -20,7 +20,7 @@ License: |
  [GNU General Public License v3.0](https://github.com/hfisser/Truck_Detection_Sentinel2_COVID19/blob/master/LICENSE)
 Resources:
  - Group: Sentinel Hub Resources
- - EndPoint: shservices.mundiwebservices.com
+ - EndPoint: https://shservices.mundiwebservices.com
    Name: Sentinel Hub
    Role: processor
    Type: byoc-6d697640-a962-4eb0-8a59-30a8cb61dc0f

--- a/collections/e12d_primary_corrected.yaml
+++ b/collections/e12d_primary_corrected.yaml
@@ -20,7 +20,7 @@ License: |
  [GNU General Public License v3.0](https://github.com/hfisser/Truck_Detection_Sentinel2_COVID19/blob/master/LICENSE)
 Resources:
  - Group: Sentinel Hub Resources
- - EndPoint: shservices.mundiwebservices.com
+ - EndPoint: https://shservices.mundiwebservices.com
    Name: Sentinel Hub
    Role: processor
    Type: byoc-d50b41de-00d7-43b5-bb69-4468d738f771

--- a/collections/e12d_primary_corrected.yaml
+++ b/collections/e12d_primary_corrected.yaml
@@ -69,4 +69,4 @@ CubeDimensions:
     values:
       - PrimaryRoadsActivity
 RegistryEntryAdded: "2021-05-07"
-RegistryEntryLastModified: "2021-09-24"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/global-human-settlement-layer-ghs-built-s2.yaml
+++ b/collections/global-human-settlement-layer-ghs-built-s2.yaml
@@ -85,4 +85,4 @@ CubeDimensions:
     values:
       - S2 Built-up probability
 RegistryEntryAdded: "2022-01-10"
-RegistryEntryLastModified: "2022-01-10"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/global-human-settlement-layer-ghs-built-s2.yaml
+++ b/collections/global-human-settlement-layer-ghs-built-s2.yaml
@@ -30,7 +30,7 @@ LicenseType: proprietary
 LicenseUrl: https://creativecommons.org/licenses/by/4.0/
 Resources:
   - Group: Sentinel Hub Resources
-    EndPoint: creodias.sentinel-hub.com
+    EndPoint: https://creodias.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: byoc-3dbeea2c-3207-4c65-8a73-c29ce2675f89

--- a/collections/global-land-cover.yaml
+++ b/collections/global-land-cover.yaml
@@ -74,7 +74,7 @@ LicenseType: proprietary
 LicenseUrl: https://land.copernicus.eu/global/about
 Resources:
   - Group: Sentinel Hub Resources
-    EndPoint: creodias.sentinel-hub.com
+    EndPoint: https://creodias.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: byoc-f0a97620-0e88-4c1f-a1ac-bb388fabdf2c

--- a/collections/global-land-cover.yaml
+++ b/collections/global-land-cover.yaml
@@ -142,4 +142,4 @@ CubeDimensions:
       - Change_Confidence_layer
       - dataMask
 RegistryEntryAdded: "2021-03-20"
-RegistryEntryLastModified: "2022-01-13"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/global-surface-water.yaml
+++ b/collections/global-surface-water.yaml
@@ -48,7 +48,7 @@ LicenseType: proprietary
 LicenseUrl: https://www.copernicus.eu/en/about-copernicus/international-cooperation
 Resources:
   - Group: Sentinel Hub Resources   
-    EndPoint: creodias.sentinel-hub.com
+    EndPoint: https://creodias.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: byoc-9a525f12-33b6-424e-a0f2-d567eec0f277

--- a/collections/global-surface-water.yaml
+++ b/collections/global-surface-water.yaml
@@ -140,4 +140,4 @@ CubeDimensions:
       - Extent
       - dataMask
 RegistryEntryAdded: "2021-04-19"
-RegistryEntryLastModified: "2021-08-18"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/iceye_e11.yaml
+++ b/collections/iceye_e11.yaml
@@ -69,4 +69,4 @@ CubeDimensions:
     values:
       - GRD
 RegistryEntryAdded: "2021-05-07"
-RegistryEntryLastModified: "2021-09-24"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/iceye_e11.yaml
+++ b/collections/iceye_e11.yaml
@@ -20,7 +20,7 @@ License: |
  The ICEYE Public Archive consists of preview images from around the world, which are released under CC BY-NC 4.0 license (https://creativecommons.org/licenses/by-nc/4.0/), allowing for non-commercial use.
 Resources:
  - Group: Sentinel Hub Resources
- - EndPoint: shservices.mundiwebservices.com
+ - EndPoint: https://shservices.mundiwebservices.com
    Name: Sentinel Hub
    Role: processor
    Type: byoc-038e4f48-7bfc-4e60-bcbf-77520327799a

--- a/collections/iceye_e11a.yaml
+++ b/collections/iceye_e11a.yaml
@@ -20,7 +20,7 @@ License: |
  The ICEYE Public Archive consists of preview images from around the world, which are released under CC BY-NC 4.0 license (https://creativecommons.org/licenses/by-nc/4.0/), allowing for non-commercial use.
 Resources:
  - Group: Sentinel Hub Resources
- - EndPoint: shservices.mundiwebservices.com
+ - EndPoint: https://shservices.mundiwebservices.com
    Name: Sentinel Hub
    Role: processor
    Type: byoc-a87a8868-5969-4df5-8a57-6441067c12d2

--- a/collections/iceye_e11a.yaml
+++ b/collections/iceye_e11a.yaml
@@ -69,4 +69,4 @@ CubeDimensions:
     values:
       - GRD
 RegistryEntryAdded: "2021-05-07"
-RegistryEntryLastModified: "2021-09-24"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/iceye_e13b.yaml
+++ b/collections/iceye_e13b.yaml
@@ -20,7 +20,7 @@ License: |
  The ICEYE Public Archive consists of preview images from around the world, which are released under CC BY-NC 4.0 license (https://creativecommons.org/licenses/by-nc/4.0/), allowing for non-commercial use.
 Resources:
  - Group: Sentinel Hub Resources
- - EndPoint: shservices.mundiwebservices.com
+ - EndPoint: https://shservices.mundiwebservices.com
    Name: Sentinel Hub
    Role: processor
    Type: byoc-6aad9f62-953a-49d0-a6e2-a2f0d5a50f77

--- a/collections/iceye_e13b.yaml
+++ b/collections/iceye_e13b.yaml
@@ -69,4 +69,4 @@ CubeDimensions:
     values:
       - GRD
 RegistryEntryAdded: "2021-05-07"
-RegistryEntryLastModified: "2021-09-24"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/iceye_e3.yaml
+++ b/collections/iceye_e3.yaml
@@ -20,7 +20,7 @@ License: |
  The ICEYE Public Archive consists of preview images from around the world, which are released under CC BY-NC 4.0 license (https://creativecommons.org/licenses/by-nc/4.0/), allowing for non-commercial use.
 Resources:
  - Group: Sentinel Hub Resources
- - EndPoint: shservices.mundiwebservices.com
+ - EndPoint: https://shservices.mundiwebservices.com
    Name: Sentinel Hub
    Role: processor
    Type: byoc-ab9106b8-29a8-4995-ae2b-043828994eb6

--- a/collections/iceye_e3.yaml
+++ b/collections/iceye_e3.yaml
@@ -69,4 +69,4 @@ CubeDimensions:
     values:
       - GRD
 RegistryEntryAdded: "2021-05-07"
-RegistryEntryLastModified: "2021-09-24"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/jaxa_wq_chla.yaml
+++ b/collections/jaxa_wq_chla.yaml
@@ -122,4 +122,4 @@ CubeDimensions:
     values:
       - chla
 RegistryEntryAdded: "2021-05-26"
-RegistryEntryLastModified: "2021-09-27"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/jaxa_wq_chla.yaml
+++ b/collections/jaxa_wq_chla.yaml
@@ -53,7 +53,7 @@ License: |
  Full, open and free access
 Resources:
   - Group: Sentinel Hub Resources
-  - EndPoint: shservices.mundiwebservices.com
+  - EndPoint: https://shservices.mundiwebservices.com
     Name: Sentinel Hub
     Role: processor
     Type: byoc-dc461d36-d855-4021-93e6-686f08d48f3d

--- a/collections/jaxa_wq_chla_average.yaml
+++ b/collections/jaxa_wq_chla_average.yaml
@@ -118,4 +118,4 @@ CubeDimensions:
       - chla
       - chla_ave
 RegistryEntryAdded: "2021-06-09"
-RegistryEntryLastModified: "2021-09-27"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/jaxa_wq_chla_average.yaml
+++ b/collections/jaxa_wq_chla_average.yaml
@@ -48,7 +48,7 @@ License: |
  Full, open and free access
 Resources:
   - Group: Sentinel Hub Resources
-  - EndPoint: services.sentinel-hub.com
+  - EndPoint: https://services.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: byoc-a81b1960-20f2-4f55-830e-b824094c4275

--- a/collections/jaxa_wq_tsm.yaml
+++ b/collections/jaxa_wq_tsm.yaml
@@ -119,4 +119,4 @@ CubeDimensions:
     values:
       - tsm
 RegistryEntryAdded: "2021-05-26"
-RegistryEntryLastModified: "2021-09-27"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/jaxa_wq_tsm.yaml
+++ b/collections/jaxa_wq_tsm.yaml
@@ -50,7 +50,7 @@ License: |
  Full, open and free access
 Resources:
   - Group: Sentinel Hub Resources
-  - EndPoint: shservices.mundiwebservices.com
+  - EndPoint: https://shservices.mundiwebservices.com
     Name: Sentinel Hub
     Role: processor
     Type: byoc-4f5f67f1-5715-4f2b-8c98-ae57948ee2f5

--- a/collections/jaxa_wq_tsm_average.yaml
+++ b/collections/jaxa_wq_tsm_average.yaml
@@ -118,4 +118,4 @@ CubeDimensions:
       - tsm
       - tsm_ave
 RegistryEntryAdded: "2021-06-06"
-RegistryEntryLastModified: "2021-09-27"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/jaxa_wq_tsm_average.yaml
+++ b/collections/jaxa_wq_tsm_average.yaml
@@ -48,7 +48,7 @@ License: |
  Full, open and free access
 Resources:
   - Group: Sentinel Hub Resources
-  - EndPoint: services.sentinel-hub.com
+  - EndPoint: https://services.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor  
     Type: byoc-d8419142-814d-48aa-ba97-bf87950f29d3

--- a/collections/landsat-1-5-mss-l1.yaml
+++ b/collections/landsat-1-5-mss-l1.yaml
@@ -91,7 +91,7 @@ CubeDimensions:
       - -180
       - 180
     reference_system:
-      $schema: https://proj.org/schemas/v0.2/projjson.schema.json
+      $schema: https://proj.org/schemas/v0.4/projjson.schema.json
       type: GeodeticCRS
       name: AUTO 42001 (Universal Transverse Mercator)
       datum:
@@ -129,7 +129,7 @@ CubeDimensions:
       - -85
       - 85
     reference_system:
-      $schema: https://proj.org/schemas/v0.2/projjson.schema.json
+      $schema: https://proj.org/schemas/v0.4/projjson.schema.json
       type: GeodeticCRS
       name: AUTO 42001 (Universal Transverse Mercator)
       datum:

--- a/collections/landsat-1-5-mss-l1.yaml
+++ b/collections/landsat-1-5-mss-l1.yaml
@@ -392,4 +392,4 @@ Summaries:
     - landsat-4
     - landsat-5
 RegistryEntryAdded: "2021-07-16"
-RegistryEntryLastModified: "2021-10-06"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/landsat-1-5-mss-l1.yaml
+++ b/collections/landsat-1-5-mss-l1.yaml
@@ -34,7 +34,7 @@ LicenseType: proprietary
 LicenseUrl: https://www.usgs.gov/centers/eros/data-citation?qt-science_support_page_related_con=0#qt-science_support_page_related_con
 Resources:
   - Group: Sentinel Hub Resources
-    EndPoint: services-uswest2.sentinel-hub.com
+    EndPoint: https://services-uswest2.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: landsat-mss-l1 

--- a/collections/landsat-4-5-tm-l1.yaml
+++ b/collections/landsat-4-5-tm-l1.yaml
@@ -462,7 +462,7 @@ Summaries:
     - 'http://www.opengis.net/def/crs/EPSG/0/32759'
     - 'http://www.opengis.net/def/crs/EPSG/0/32760'
     - 'http://www.opengis.net/def/crs/SR-ORG/0/98739'
-  eo:gsd:
+  gsd:
     - 30
   platform:
     - landsat-4

--- a/collections/landsat-4-5-tm-l1.yaml
+++ b/collections/landsat-4-5-tm-l1.yaml
@@ -35,7 +35,7 @@ LicenseType: proprietary
 LicenseUrl: https://www.usgs.gov/centers/eros/data-citation?qt-science_support_page_related_con=0#qt-science_support_page_related_con
 Resources:
   - Group: Sentinel Hub Resources
-    EndPoint: services-uswest2.sentinel-hub.com
+    EndPoint: https://services-uswest2.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: landsat-tm-l1 

--- a/collections/landsat-4-5-tm-l1.yaml
+++ b/collections/landsat-4-5-tm-l1.yaml
@@ -110,7 +110,7 @@ CubeDimensions:
       - -180
       - 180
     reference_system:
-      $schema: https://proj.org/schemas/v0.2/projjson.schema.json
+      $schema: https://proj.org/schemas/v0.4/projjson.schema.json
       type: GeodeticCRS
       name: AUTO 42001 (Universal Transverse Mercator)
       datum:
@@ -148,7 +148,7 @@ CubeDimensions:
       - -85
       - 85
     reference_system:
-      $schema: https://proj.org/schemas/v0.2/projjson.schema.json
+      $schema: https://proj.org/schemas/v0.4/projjson.schema.json
       type: GeodeticCRS
       name: AUTO 42001 (Universal Transverse Mercator)
       datum:

--- a/collections/landsat-4-5-tm-l1.yaml
+++ b/collections/landsat-4-5-tm-l1.yaml
@@ -468,4 +468,4 @@ Summaries:
     - landsat-4
     - landsat-5
 RegistryEntryAdded: "2021-05-12"
-RegistryEntryLastModified: "2021-12-06"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/landsat-4-5-tm-l2.yaml
+++ b/collections/landsat-4-5-tm-l2.yaml
@@ -517,4 +517,4 @@ Summaries:
     - landsat-4
     - landsat-5
 RegistryEntryAdded: "2021-05-12"
-RegistryEntryLastModified: "2021-10-06"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/landsat-4-5-tm-l2.yaml
+++ b/collections/landsat-4-5-tm-l2.yaml
@@ -511,7 +511,7 @@ Summaries:
     - 'http://www.opengis.net/def/crs/EPSG/0/32759'
     - 'http://www.opengis.net/def/crs/EPSG/0/32760'
     - 'http://www.opengis.net/def/crs/SR-ORG/0/98739'
-  eo:gsd:
+  gsd:
     - 30
   platform:
     - landsat-4

--- a/collections/landsat-4-5-tm-l2.yaml
+++ b/collections/landsat-4-5-tm-l2.yaml
@@ -111,7 +111,7 @@ CubeDimensions:
       - -180
       - 180
     reference_system:
-      $schema: https://proj.org/schemas/v0.2/projjson.schema.json
+      $schema: https://proj.org/schemas/v0.4/projjson.schema.json
       type: GeodeticCRS
       name: AUTO 42001 (Universal Transverse Mercator)
       datum:
@@ -149,7 +149,7 @@ CubeDimensions:
       - -85
       - 85
     reference_system:
-      $schema: https://proj.org/schemas/v0.2/projjson.schema.json
+      $schema: https://proj.org/schemas/v0.4/projjson.schema.json
       type: GeodeticCRS
       name: AUTO 42001 (Universal Transverse Mercator)
       datum:

--- a/collections/landsat-4-5-tm-l2.yaml
+++ b/collections/landsat-4-5-tm-l2.yaml
@@ -36,7 +36,7 @@ LicenseType: proprietary
 LicenseUrl: https://www.usgs.gov/centers/eros/data-citation?qt-science_support_page_related_con=0#qt-science_support_page_related_con
 Resources:
   - Group: Sentinel Hub Resources
-    EndPoint: services-uswest2.sentinel-hub.com
+    EndPoint: https://services-uswest2.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: landsat-tm-l2

--- a/collections/landsat-7-etm+-l1.yaml
+++ b/collections/landsat-7-etm+-l1.yaml
@@ -483,4 +483,4 @@ Summaries:
   platform:
     - landsat-7
 RegistryEntryAdded: "2021-07-16"
-RegistryEntryLastModified: "2021-12-06"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/landsat-7-etm+-l1.yaml
+++ b/collections/landsat-7-etm+-l1.yaml
@@ -30,7 +30,7 @@ LicenseType: proprietary
 LicenseUrl: https://www.usgs.gov/centers/eros/data-citation?qt-science_support_page_related_con=0#qt-science_support_page_related_con
 Resources:
   - Group: Sentinel Hub Resources
-    EndPoint: services-uswest2.sentinel-hub.com
+    EndPoint: https://services-uswest2.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: landsat-etm-l1

--- a/collections/landsat-7-etm+-l1.yaml
+++ b/collections/landsat-7-etm+-l1.yaml
@@ -99,7 +99,7 @@ CubeDimensions:
       - -180
       - 180
     reference_system:
-      $schema: https://proj.org/schemas/v0.2/projjson.schema.json
+      $schema: https://proj.org/schemas/v0.4/projjson.schema.json
       type: GeodeticCRS
       name: AUTO 42001 (Universal Transverse Mercator)
       datum:
@@ -137,7 +137,7 @@ CubeDimensions:
       - -85
       - 85
     reference_system:
-      $schema: https://proj.org/schemas/v0.2/projjson.schema.json
+      $schema: https://proj.org/schemas/v0.4/projjson.schema.json
       type: GeodeticCRS
       name: AUTO 42001 (Universal Transverse Mercator)
       datum:

--- a/collections/landsat-7-etm+-l2.yaml
+++ b/collections/landsat-7-etm+-l2.yaml
@@ -30,7 +30,7 @@ LicenseType: proprietary
 LicenseUrl: https://www.usgs.gov/centers/eros/data-citation?qt-science_support_page_related_con=0#qt-science_support_page_related_con
 Resources:
   - Group: Sentinel Hub Resources
-    EndPoint: services-uswest2.sentinel-hub.com
+    EndPoint: https://services-uswest2.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: landsat-etm-l2

--- a/collections/landsat-7-etm+-l2.yaml
+++ b/collections/landsat-7-etm+-l2.yaml
@@ -515,4 +515,4 @@ Summaries:
   platform:
     - landsat-7
 RegistryEntryAdded: "2021-07-16"
-RegistryEntryLastModified: "2021-12-06"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/landsat-7-etm+-l2.yaml
+++ b/collections/landsat-7-etm+-l2.yaml
@@ -105,7 +105,7 @@ CubeDimensions:
       - -180
       - 180
     reference_system:
-      $schema: https://proj.org/schemas/v0.2/projjson.schema.json
+      $schema: https://proj.org/schemas/v0.4/projjson.schema.json
       type: GeodeticCRS
       name: AUTO 42001 (Universal Transverse Mercator)
       datum:
@@ -143,7 +143,7 @@ CubeDimensions:
       - -85
       - 85
     reference_system:
-      $schema: https://proj.org/schemas/v0.2/projjson.schema.json
+      $schema: https://proj.org/schemas/v0.4/projjson.schema.json
       type: GeodeticCRS
       name: AUTO 42001 (Universal Transverse Mercator)
       datum:

--- a/collections/landsat-8-l1.yaml
+++ b/collections/landsat-8-l1.yaml
@@ -36,7 +36,7 @@ LicenseType: proprietary
 LicenseUrl: https://www.usgs.gov/centers/eros/data-citation?qt-science_support_page_related_con=0#qt-science_support_page_related_con
 Resources:
   - Group: Sentinel Hub Resources
-    EndPoint: services-uswest2.sentinel-hub.com
+    EndPoint: https://services-uswest2.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: landsat-ot-l1 

--- a/collections/landsat-8-l1.yaml
+++ b/collections/landsat-8-l1.yaml
@@ -121,7 +121,7 @@ CubeDimensions:
       - -180
       - 180
     reference_system:
-      $schema: https://proj.org/schemas/v0.2/projjson.schema.json
+      $schema: https://proj.org/schemas/v0.4/projjson.schema.json
       type: GeodeticCRS
       name: AUTO 42001 (Universal Transverse Mercator)
       datum:
@@ -159,7 +159,7 @@ CubeDimensions:
       - -85
       - 85
     reference_system:
-      $schema: https://proj.org/schemas/v0.2/projjson.schema.json
+      $schema: https://proj.org/schemas/v0.4/projjson.schema.json
       type: GeodeticCRS
       name: AUTO 42001 (Universal Transverse Mercator)
       datum:

--- a/collections/landsat-8-l1.yaml
+++ b/collections/landsat-8-l1.yaml
@@ -529,4 +529,4 @@ Summaries:
   platform:
     - landsat-8
 RegistryEntryAdded: "2018-04-17"
-RegistryEntryLastModified: "2022-02-01"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/landsat-8-l2.yaml
+++ b/collections/landsat-8-l2.yaml
@@ -531,4 +531,4 @@ Summaries:
   platform:
     - landsat-8
 RegistryEntryAdded: "2018-04-17"
-RegistryEntryLastModified: "2022-02-01"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/landsat-8-l2.yaml
+++ b/collections/landsat-8-l2.yaml
@@ -116,7 +116,7 @@ CubeDimensions:
       - -180
       - 180
     reference_system:
-      $schema: https://proj.org/schemas/v0.2/projjson.schema.json
+      $schema: https://proj.org/schemas/v0.4/projjson.schema.json
       type: GeodeticCRS
       name: AUTO 42001 (Universal Transverse Mercator)
       datum:
@@ -154,7 +154,7 @@ CubeDimensions:
       - -85
       - 85
     reference_system:
-      $schema: https://proj.org/schemas/v0.2/projjson.schema.json
+      $schema: https://proj.org/schemas/v0.4/projjson.schema.json
       type: GeodeticCRS
       name: AUTO 42001 (Universal Transverse Mercator)
       datum:

--- a/collections/landsat-8-l2.yaml
+++ b/collections/landsat-8-l2.yaml
@@ -37,7 +37,7 @@ LicenseType: proprietary
 LicenseUrl: https://www.usgs.gov/centers/eros/data-citation?qt-science_support_page_related_con=0#qt-science_support_page_related_con
 Resources:
   - Group: Sentinel Hub Resources
-    EndPoint: services-uswest2.sentinel-hub.com
+    EndPoint: https://services-uswest2.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: landsat-ot-l2 

--- a/collections/mapzen-dem.yaml
+++ b/collections/mapzen-dem.yaml
@@ -127,4 +127,4 @@ Summaries:
     - description: The mask of data/no data pixels.
       name: dataMask
 RegistryEntryAdded: "2018-04-17"
-RegistryEntryLastModified: "2022-01-27"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/mapzen-dem.yaml
+++ b/collections/mapzen-dem.yaml
@@ -32,7 +32,7 @@ LicenseType: proprietary
 LicenseUrl: https://www.mapzen.com/terms/
 Resources:
   - Group: Sentinel Hub Resources
-  - EndPoint: services-uswest2.sentinel-hub.com
+  - EndPoint: https://services-uswest2.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: dem

--- a/collections/mapzen-dem.yaml
+++ b/collections/mapzen-dem.yaml
@@ -39,7 +39,7 @@ Resources:
     DemInstance: MAPZEN
     Notes: Global 
     Primary: true
-  - EndPoint: services.sentinel-hub.com
+  - EndPoint: https://services.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: dem

--- a/collections/modis.yaml
+++ b/collections/modis.yaml
@@ -354,7 +354,7 @@ Summaries:
     - 'http://www.opengis.net/def/crs/EPSG/0/32759'
     - 'http://www.opengis.net/def/crs/EPSG/0/32760'
     - 'http://www.opengis.net/def/crs/SR-ORG/0/98739'
-  eo:gsd:
+  gsd:
     - 500
   platform:
     - Terra

--- a/collections/modis.yaml
+++ b/collections/modis.yaml
@@ -360,4 +360,4 @@ Summaries:
     - Terra
     - Aqua
 RegistryEntryAdded: "2018-04-17"
-RegistryEntryLastModified: "2022-01-20"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/modis.yaml
+++ b/collections/modis.yaml
@@ -38,7 +38,7 @@ LicenseType: proprietary
 LicenseUrl: https://www.usgs.gov/centers/eros/data-citation?qt-science_support_page_related_con=0#qt-science_support_page_related_con
 Resources:
   - Group: Sentinel Hub Resources
-    EndPoint: services-uswest2.sentinel-hub.com
+    EndPoint: https://services-uswest2.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: modis 

--- a/collections/planetscope.yaml
+++ b/collections/planetscope.yaml
@@ -30,7 +30,7 @@ License: |
   [License](https://docs.sentinel-hub.com/api/latest/data/planet-scope/#attribution-and-use)
 Resources:
   - Group: Sentinel Hub Resources   
-    EndPoint: services.sentinel-hub.com
+    EndPoint: https://services.sentinel-hub.com
     Type: CUSTOM
     CollectionId: known to user after purchase
     Notes: Contains the data purchased by individual user

--- a/collections/planetscope.yaml
+++ b/collections/planetscope.yaml
@@ -39,4 +39,4 @@ CustomScripts:
     URL: https://custom-scripts.sentinel-hub.com/#planet_scope
 
 RegistryEntryAdded: "2018-04-17"
-RegistryEntryLastModified: "2021-05-05"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/pleiades.yaml
+++ b/collections/pleiades.yaml
@@ -33,7 +33,7 @@ License: |
   [License](https://docs.sentinel-hub.com/api/latest/data/airbus/pleiades/#attribution-and-use)
 Resources:
   - Group: Sentinel Hub Resources   
-    EndPoint: services.sentinel-hub.com
+    EndPoint: https://services.sentinel-hub.com
     Type: CUSTOM
     CollectionId: known to user after purchase
     Notes: Contains the data purchased by individual user

--- a/collections/pleiades.yaml
+++ b/collections/pleiades.yaml
@@ -42,4 +42,4 @@ CustomScripts:
     URL: https://custom-scripts.sentinel-hub.com/#airbus_pleiades
 
 RegistryEntryAdded: "2018-04-17"
-RegistryEntryLastModified: "2021-05-05"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/population_density.yaml
+++ b/collections/population_density.yaml
@@ -70,4 +70,4 @@ CubeDimensions:
     values:
       - populationDensity   
 RegistryEntryAdded: "2021-05-07"
-RegistryEntryLastModified: "2021-09-24"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/population_density.yaml
+++ b/collections/population_density.yaml
@@ -21,7 +21,7 @@ License: |
  The GPW data collection is licensed under the Creative Commons Attribution 4.0 International License (http://creativecommons.org/licenses/by/4.0), thus providing openly-available, gridded population data that maintains fidelity to the input census data. This is an advantage of GPW because minimally modeled census information may be analyzed in conjunction with other data sets, such as land cover and elevation, without concern for endogeneity, or double counting ([details] (https://sedac.ciesin.columbia.edu/data/collection/gpw-v4)).
 Resources:
  - Group: Sentinel Hub Resources
- - EndPoint: shservices.mundiwebservices.com
+ - EndPoint: https://shservices.mundiwebservices.com
    Name: Sentinel Hub
    Role: processor 
    Type: byoc-a9743257-ef21-4fd3-999d-15c5c7fcacbd

--- a/collections/s5p-no2-tropno-daily-check.yaml
+++ b/collections/s5p-no2-tropno-daily-check.yaml
@@ -69,4 +69,4 @@ CubeDimensions:
     values:
       - tropno2
 RegistryEntryAdded: "2021-05-07"
-RegistryEntryLastModified: "2021-09-24"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/s5p-no2-tropno-daily-check.yaml
+++ b/collections/s5p-no2-tropno-daily-check.yaml
@@ -20,7 +20,7 @@ Tags:
 License: Full, open and free access
 Resources:
  - Group: Sentinel Hub Resources
- - EndPoint: shservices.mundiwebservices.com
+ - EndPoint: https://shservices.mundiwebservices.com
    Name: Sentinel Hub
    Role: processor
    Type: byoc-bb92282c-b580-4206-b843-76daffbb5b0a

--- a/collections/sea-ice-index.yaml
+++ b/collections/sea-ice-index.yaml
@@ -38,7 +38,7 @@ LicenseType: proprietary
 LicenseUrl: https://nsidc.org/about/use_copyright.html.
 Resources:
   - Group: Sentinel Hub Resources
-    EndPoint: creodias.sentinel-hub.com
+    EndPoint: https://creodias.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: byoc-10549890-13bb-4ec5-8ae0-df387bd0b785

--- a/collections/sea-ice-index.yaml
+++ b/collections/sea-ice-index.yaml
@@ -83,4 +83,4 @@ CubeDimensions:
       - extent
       - dataMask
 RegistryEntryAdded: "2021-05-11"
-RegistryEntryLastModified: "2021-08-18"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/seasonal-trajectories.yaml
+++ b/collections/seasonal-trajectories.yaml
@@ -60,7 +60,7 @@ LicenseType: proprietary
 LicenseUrl: https://land.copernicus.eu/terms-of-use
 Resources:
   - Group: Sentinel Hub Resources
-  - EndPoint: creodias.sentinel-hub.com
+  - EndPoint: https://creodias.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: byoc-90f0abac-87cf-4277-958b-d8c56d9e5371

--- a/collections/seasonal-trajectories.yaml
+++ b/collections/seasonal-trajectories.yaml
@@ -118,4 +118,4 @@ CubeDimensions:
       - QFLAG
       - dataMask
 RegistryEntryAdded: '2021-10-14'
-RegistryEntryLastModified: '2022-01-13'
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/sentinel-1-grd.yaml
+++ b/collections/sentinel-1-grd.yaml
@@ -52,7 +52,7 @@ Resources:
     Role: processor
     Type: sentinel-1-grd
     Notes: Global since October 2014
-  - EndPoint: shservices.mundiwebservices.com
+  - EndPoint: https://shservices.mundiwebservices.com
     Name: Sentinel Hub
     Role: processor
     Type: sentinel-1-grd

--- a/collections/sentinel-1-grd.yaml
+++ b/collections/sentinel-1-grd.yaml
@@ -47,7 +47,7 @@ Resources:
     Type: sentinel-1-grd
     Notes: Global since October 2014
     Primary: true
-  - EndPoint: eocloud.sentinel-hub.com
+  - EndPoint: https://eocloud.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: sentinel-1-grd

--- a/collections/sentinel-1-grd.yaml
+++ b/collections/sentinel-1-grd.yaml
@@ -41,7 +41,7 @@ LicenseType: proprietary
 LicenseUrl: https://docs.sentinel-hub.com/api/latest/data/sentinel-1-grd/#attribution-and-use
 Resources:
   - Group: Sentinel Hub Resources
-  - EndPoint: services.sentinel-hub.com
+  - EndPoint: https://services.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: sentinel-1-grd

--- a/collections/sentinel-1-grd.yaml
+++ b/collections/sentinel-1-grd.yaml
@@ -351,4 +351,4 @@ Summaries:
     - 'http://www.opengis.net/def/crs/EPSG/0/32760'
     - 'http://www.opengis.net/def/crs/SR-ORG/0/98739'
 RegistryEntryAdded: "2018-04-17"
-RegistryEntryLastModified: "2022-01-27"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/sentinel-2-l1c.yaml
+++ b/collections/sentinel-2-l1c.yaml
@@ -42,7 +42,7 @@ Resources:
     Type: sentinel-2-l1c
     Notes: Global since November 2015
     Primary: true
-  - EndPoint: creodias.sentinel-hub.com
+  - EndPoint: https://creodias.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: sentinel-2-l1c

--- a/collections/sentinel-2-l1c.yaml
+++ b/collections/sentinel-2-l1c.yaml
@@ -132,7 +132,7 @@ CubeDimensions:
       - -180
       - 180
     reference_system:
-      $schema: https://proj.org/schemas/v0.2/projjson.schema.json
+      $schema: https://proj.org/schemas/v0.4/projjson.schema.json
       type: GeodeticCRS
       name: AUTO 42001 (Universal Transverse Mercator)
       datum:
@@ -170,7 +170,7 @@ CubeDimensions:
       - -56
       - 83
     reference_system:
-      $schema: https://proj.org/schemas/v0.2/projjson.schema.json
+      $schema: https://proj.org/schemas/v0.4/projjson.schema.json
       type: GeodeticCRS
       name: AUTO 42001 (Universal Transverse Mercator)
       datum:

--- a/collections/sentinel-2-l1c.yaml
+++ b/collections/sentinel-2-l1c.yaml
@@ -47,7 +47,7 @@ Resources:
     Role: processor
     Type: sentinel-2-l1c
     Notes: Global since November 2015
-  - EndPoint: code-de.sentinel-hub.com
+  - EndPoint: https://code-de.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: sentinel-2-l1c

--- a/collections/sentinel-2-l1c.yaml
+++ b/collections/sentinel-2-l1c.yaml
@@ -535,7 +535,7 @@ Summaries:
     - 'http://www.opengis.net/def/crs/EPSG/0/32759'
     - 'http://www.opengis.net/def/crs/EPSG/0/32760'
     - 'http://www.opengis.net/def/crs/SR-ORG/0/98739'
-  eo:gsd:
+  gsd:
     - 10
     - 30
     - 60

--- a/collections/sentinel-2-l1c.yaml
+++ b/collections/sentinel-2-l1c.yaml
@@ -36,7 +36,7 @@ LicenseType: proprietary
 LicenseUrl: https://docs.sentinel-hub.com/api/latest/data/sentinel-2-l1c/#attribution-and-use
 Resources:
   - Group: Sentinel Hub Resources
-  - EndPoint: services.sentinel-hub.com
+  - EndPoint: https://services.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: sentinel-2-l1c

--- a/collections/sentinel-2-l1c.yaml
+++ b/collections/sentinel-2-l1c.yaml
@@ -545,4 +545,4 @@ Summaries:
     - sentinel-2a
     - sentinel-2b
 RegistryEntryAdded: "2018-04-17"
-RegistryEntryLastModified: "2021-12-16"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/sentinel-2-l1c.yaml
+++ b/collections/sentinel-2-l1c.yaml
@@ -52,7 +52,7 @@ Resources:
     Role: processor
     Type: sentinel-2-l1c
     Notes: Germany since July 2015
-  - EndPoint: shservices.mundiwebservices.com
+  - EndPoint: https://shservices.mundiwebservices.com
     Type: sentinel-2-l1c
     Name: Sentinel Hub
     Role: processor

--- a/collections/sentinel-2-l2a.yaml
+++ b/collections/sentinel-2-l2a.yaml
@@ -37,7 +37,7 @@ LicenseType: proprietary
 LicenseUrl: https://docs.sentinel-hub.com/api/latest/data/sentinel-2-l2a/#attribution-and-use
 Resources:
   - Group: Sentinel Hub Resources
-  - EndPoint: services.sentinel-hub.com
+  - EndPoint: https://services.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: sentinel-2-l2a

--- a/collections/sentinel-2-l2a.yaml
+++ b/collections/sentinel-2-l2a.yaml
@@ -554,7 +554,7 @@ Summaries:
     - http://www.opengis.net/def/crs/EPSG/0/32759
     - http://www.opengis.net/def/crs/EPSG/0/32760
     - http://www.opengis.net/def/crs/SR-ORG/0/98739
-  eo:gsd:
+  gsd:
     - 10
     - 30
     - 60

--- a/collections/sentinel-2-l2a.yaml
+++ b/collections/sentinel-2-l2a.yaml
@@ -43,7 +43,7 @@ Resources:
     Type: sentinel-2-l2a
     Notes: Europe since November 2016, Global since January 2017
     Primary: true
-  - EndPoint: shservices.mundiwebservices.com
+  - EndPoint: https://shservices.mundiwebservices.com
     Name: Sentinel Hub
     Role: processor
     Type: sentinel-2-l2a

--- a/collections/sentinel-2-l2a.yaml
+++ b/collections/sentinel-2-l2a.yaml
@@ -129,7 +129,7 @@ CubeDimensions:
       - -180
       - 180
     reference_system:
-      $schema: https://proj.org/schemas/v0.2/projjson.schema.json
+      $schema: https://proj.org/schemas/v0.4/projjson.schema.json
       type: GeodeticCRS
       name: AUTO 42001 (Universal Transverse Mercator)
       datum:
@@ -167,7 +167,7 @@ CubeDimensions:
       - -56
       - 83
     reference_system:
-      $schema: https://proj.org/schemas/v0.2/projjson.schema.json
+      $schema: https://proj.org/schemas/v0.4/projjson.schema.json
       type: GeodeticCRS
       name: AUTO 42001 (Universal Transverse Mercator)
       datum:

--- a/collections/sentinel-2-l2a.yaml
+++ b/collections/sentinel-2-l2a.yaml
@@ -564,4 +564,4 @@ Summaries:
     - sentinel-2a
     - sentinel-2b
 RegistryEntryAdded: '2018-04-17'
-RegistryEntryLastModified: '2021-12-16'
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/sentinel-3-l1b-olci.yaml
+++ b/collections/sentinel-3-l1b-olci.yaml
@@ -543,7 +543,7 @@ Summaries:
     - 'http://www.opengis.net/def/crs/EPSG/0/32759'
     - 'http://www.opengis.net/def/crs/EPSG/0/32760'
     - 'http://www.opengis.net/def/crs/SR-ORG/0/98739'
-  eo:gsd:
+  gsd:
     - 300
   platform:
     - sentinel-3a

--- a/collections/sentinel-3-l1b-olci.yaml
+++ b/collections/sentinel-3-l1b-olci.yaml
@@ -46,7 +46,7 @@ Resources:
     Type: sentinel-3-olci
     Notes: Global since May 2016
     Primary: true
-  - EndPoint: code-de.sentinel-hub.com
+  - EndPoint: https://code-de.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: sentinel-3-olci

--- a/collections/sentinel-3-l1b-olci.yaml
+++ b/collections/sentinel-3-l1b-olci.yaml
@@ -549,4 +549,4 @@ Summaries:
     - sentinel-3a
     - sentinel-3b
 RegistryEntryAdded: "2018-04-17"
-RegistryEntryLastModified: "2022-01-17"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/sentinel-3-l1b-olci.yaml
+++ b/collections/sentinel-3-l1b-olci.yaml
@@ -40,7 +40,7 @@ LicenseType: proprietary
 LicenseUrl: https://docs.sentinel-hub.com/api/latest/data/sentinel-1-grd/#attribution-and-use
 Resources:
   - Group: Sentinel Hub Resources
-  - EndPoint: creodias.sentinel-hub.com
+  - EndPoint: https://creodias.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: sentinel-3-olci

--- a/collections/sentinel-3-l1b-slstr.yaml
+++ b/collections/sentinel-3-l1b-slstr.yaml
@@ -369,7 +369,7 @@ Summaries:
     - 'http://www.opengis.net/def/crs/EPSG/0/32759'
     - 'http://www.opengis.net/def/crs/EPSG/0/32760'
     - 'http://www.opengis.net/def/crs/SR-ORG/0/98739'
-  eo:gsd:
+  gsd:
     - 500
     - 1000
   platform:

--- a/collections/sentinel-3-l1b-slstr.yaml
+++ b/collections/sentinel-3-l1b-slstr.yaml
@@ -40,7 +40,7 @@ LicenseType: proprietary
 LicenseUrl: https://docs.sentinel-hub.com/api/latest/data/sentinel-3-slstr-l1b/#attribution-and-use
 Resources:
   - Group: Sentinel Hub Resources
-  - EndPoint: creodias.sentinel-hub.com
+  - EndPoint: https://creodias.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: sentinel-3-slstr 

--- a/collections/sentinel-3-l1b-slstr.yaml
+++ b/collections/sentinel-3-l1b-slstr.yaml
@@ -376,4 +376,4 @@ Summaries:
     - sentinel-3a
     - sentinel-3b
 RegistryEntryAdded: "2018-04-17"
-RegistryEntryLastModified: "2022-01-20"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/sentinel-3-l1b-slstr.yaml
+++ b/collections/sentinel-3-l1b-slstr.yaml
@@ -46,7 +46,7 @@ Resources:
     Type: sentinel-3-slstr 
     Notes: Global since May 2016
     Primary: true
-  - EndPoint: code-de.sentinel-hub.com
+  - EndPoint: https://code-de.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: sentinel-3-slstr 

--- a/collections/sentinel-5p-l2-tropomi.yaml
+++ b/collections/sentinel-5p-l2-tropomi.yaml
@@ -49,7 +49,7 @@ Resources:
     Role: processor
     Type: sentinel-5p-l2
     Notes: Global since May 2018
-  - EndPoint: code-de.sentinel-hub.com
+  - EndPoint: https://code-de.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: sentinel-5p-l2

--- a/collections/sentinel-5p-l2-tropomi.yaml
+++ b/collections/sentinel-5p-l2-tropomi.yaml
@@ -429,4 +429,4 @@ Summaries:
   platform: 
   - sentinel-5 precursor
 RegistryEntryAdded: "2018-04-17"
-RegistryEntryLastModified: "2022-01-20"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/sentinel-5p-l2-tropomi.yaml
+++ b/collections/sentinel-5p-l2-tropomi.yaml
@@ -44,7 +44,7 @@ Resources:
     Type: sentinel-5p-l2
     Notes: Global since May 2018
     Primary: true
-  - EndPoint: shservices.mundiwebservices.com
+  - EndPoint: https://shservices.mundiwebservices.com
     Name: Sentinel Hub
     Role: processor
     Type: sentinel-5p-l2

--- a/collections/sentinel-5p-l2-tropomi.yaml
+++ b/collections/sentinel-5p-l2-tropomi.yaml
@@ -38,7 +38,7 @@ LicenseType: proprietary
 LicenseUrl: https://docs.sentinel-hub.com/api/latest/data/sentinel-5p-l2/#attribution-and-use
 Resources:
   - Group: Sentinel Hub Resources
-  - EndPoint: creodias.sentinel-hub.com
+  - EndPoint: https://creodias.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: sentinel-5p-l2

--- a/collections/sentinel-5p-l2-tropomi.yaml
+++ b/collections/sentinel-5p-l2-tropomi.yaml
@@ -424,7 +424,7 @@ Summaries:
     - 'http://www.opengis.net/def/crs/EPSG/0/32759'
     - 'http://www.opengis.net/def/crs/EPSG/0/32760'
     - 'http://www.opengis.net/def/crs/SR-ORG/0/98739'
-  eo:gsd: 
+  gsd: 
   - 7000
   platform: 
   - sentinel-5 precursor

--- a/collections/sentinel-s2-l2a-mosaic-120.yaml
+++ b/collections/sentinel-s2-l2a-mosaic-120.yaml
@@ -81,7 +81,7 @@ LicenseType: proprietary
 LicenseUrl: https://www.sentinel-hub.com/tos/#collection
 Resources:
   - Group: Sentinel Hub Resources
-  - EndPoint: services.sentinel-hub.com
+  - EndPoint: https://services.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: byoc-484d8dbb-9e3e-41f2-b96b-35189d3ae37f

--- a/collections/sentinel-s2-l2a-mosaic-120.yaml
+++ b/collections/sentinel-s2-l2a-mosaic-120.yaml
@@ -192,4 +192,4 @@ CubeDimensions:
       - QM
       - dataMask
 RegistryEntryAdded: "2021-03-21"
-RegistryEntryLastModified: "2021-10-06"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/spot.yaml
+++ b/collections/spot.yaml
@@ -32,7 +32,7 @@ License: |
   [License](https://docs.sentinel-hub.com/api/latest/data/airbus/spot/#attribution-and-use)
 Resources:
   - Group: Sentinel Hub Resources
-    EndPoint: services.sentinel-hub.com
+    EndPoint: https://services.sentinel-hub.com
     Type: CUSTOM
     CollectionId: known to user after purchase
     Notes: Contains the data purchased by individual user

--- a/collections/spot.yaml
+++ b/collections/spot.yaml
@@ -42,4 +42,4 @@ CustomScripts:
 
 
 RegistryEntryAdded: "2020-06-17"
-RegistryEntryLastModified: "2021-05-05"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/tsmn_water_quality_saturday.yaml
+++ b/collections/tsmn_water_quality_saturday.yaml
@@ -70,4 +70,4 @@ CubeDimensions:
     values:
       - tsmnn
 RegistryEntryAdded: "2021-05-07"
-RegistryEntryLastModified: "2021-09-24"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/tsmn_water_quality_saturday.yaml
+++ b/collections/tsmn_water_quality_saturday.yaml
@@ -21,7 +21,7 @@ License: |
  [CC BY-NC-ND 3.0](https://creativecommons.org/licenses/by-nc-nd/3.0/), Credit: Provided by ISMAR Istituto di Scienze Marine at Consiglio Nazionale delle Ricerche
 Resources:
  - Group: Sentinel Hub Resources
- - EndPoint: shservices.mundiwebservices.com
+ - EndPoint: https://shservices.mundiwebservices.com
    Name: Sentinel Hub
    Role: processor
    Type: byoc-45ce0fb2-fdaf-481e-b834-f728a8677e59

--- a/collections/vegetation-indices.yaml
+++ b/collections/vegetation-indices.yaml
@@ -158,4 +158,4 @@ CubeDimensions:
       - QFLAG2
       - dataMask
 RegistryEntryAdded: '2021-10-14'
-RegistryEntryLastModified: '2022-01-13'
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/vegetation-indices.yaml
+++ b/collections/vegetation-indices.yaml
@@ -78,7 +78,7 @@ LicenseType: proprietary
 LicenseUrl: https://land.copernicus.eu/terms-of-use
 Resources:
   - Group: Sentinel Hub Resources
-  - EndPoint: creodias.sentinel-hub.com
+  - EndPoint: https://creodias.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: byoc-472c0398-430d-4157-a62d-603363d7a4e8

--- a/collections/vegetation-phenology-and-productivity-parameters-season-1.yaml
+++ b/collections/vegetation-phenology-and-productivity-parameters-season-1.yaml
@@ -256,4 +256,4 @@ CubeDimensions:
       - RSLOPE
       - dataMask
 RegistryEntryAdded: '2021-10-14'
-RegistryEntryLastModified: '2022-01-13'
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/vegetation-phenology-and-productivity-parameters-season-1.yaml
+++ b/collections/vegetation-phenology-and-productivity-parameters-season-1.yaml
@@ -137,7 +137,7 @@ LicenseType: proprietary
 LicenseUrl: https://land.copernicus.eu/terms-of-use
 Resources:
   - Group: Sentinel Hub Resources
-  - EndPoint: creodias.sentinel-hub.com
+  - EndPoint: https://creodias.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: byoc-67c73156-095d-4f53-8a09-9ddf3848fbb6

--- a/collections/vegetation-phenology-and-productivity-parameters-season-2.yaml
+++ b/collections/vegetation-phenology-and-productivity-parameters-season-2.yaml
@@ -256,4 +256,4 @@ CubeDimensions:
       - RSLOPE
       - dataMask
 RegistryEntryAdded: '2021-10-14'
-RegistryEntryLastModified: '2022-01-13'
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/vegetation-phenology-and-productivity-parameters-season-2.yaml
+++ b/collections/vegetation-phenology-and-productivity-parameters-season-2.yaml
@@ -137,7 +137,7 @@ LicenseType: proprietary
 LicenseUrl: https://land.copernicus.eu/terms-of-use
 Resources:
   - Group: Sentinel Hub Resources
-  - EndPoint: creodias.sentinel-hub.com
+  - EndPoint: https://creodias.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: byoc-8c2bc96a-3c2c-482b-9394-031310171b33

--- a/collections/water-bodies.yaml
+++ b/collections/water-bodies.yaml
@@ -42,7 +42,7 @@ LicenseType: proprietary
 LicenseUrl: https://land.copernicus.eu/global/about
 Resources:
   - Group: Sentinel Hub Resources   
-    EndPoint: creodias.sentinel-hub.com
+    EndPoint: https://creodias.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: byoc-62bf6f6a-c584-48a8-a739-0bc60efee54a

--- a/collections/water-bodies.yaml
+++ b/collections/water-bodies.yaml
@@ -106,4 +106,4 @@ CubeDimensions:
       - QUAL
       - dataMask
 RegistryEntryAdded: "2021-03-30"
-RegistryEntryLastModified: "2022-01-13"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/wind_10m_u.yaml
+++ b/collections/wind_10m_u.yaml
@@ -71,4 +71,4 @@ CubeDimensions:
     values:
       - windu10m
 RegistryEntryAdded: "2021-05-07"
-RegistryEntryLastModified: "2022-01-13"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/wind_10m_u.yaml
+++ b/collections/wind_10m_u.yaml
@@ -22,7 +22,7 @@ License: |
  Free of charge, worldwide, non-exclusive, royalty free and perpetual ([details](https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-land-monthly-means?tab=overview))
 Resources:
  - Group: Sentinel Hub Resources
- - EndPoint: shservices.mundiwebservices.com
+ - EndPoint: https://shservices.mundiwebservices.com
    Name: Sentinel Hub
    Role: processor
    Type: byoc-e54d24b0-3a92-41ea-a759-c954e3a9203e

--- a/collections/wind_10m_v.yaml
+++ b/collections/wind_10m_v.yaml
@@ -71,4 +71,4 @@ CubeDimensions:
     values:
       - windv10m
 RegistryEntryAdded: "2021-05-07"
-RegistryEntryLastModified: "2022-01-13"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/wind_10m_v.yaml
+++ b/collections/wind_10m_v.yaml
@@ -22,7 +22,7 @@ License: |
  Free of charge, worldwide, non-exclusive, royalty free and perpetual ([details](https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-land-monthly-means?tab=overview))
 Resources:
  - Group: Sentinel Hub Resources
- - EndPoint: shservices.mundiwebservices.com
+ - EndPoint: https://shservices.mundiwebservices.com
    Name: Sentinel Hub
    Role: processor
    Type: byoc-72139a6c-8fa3-4a90-93ca-4c1d792cc8af

--- a/collections/worldcover.yaml
+++ b/collections/worldcover.yaml
@@ -92,4 +92,4 @@ CubeDimensions:
       - Map
       - dataMask
 RegistryEntryAdded: "2021-10-19"
-RegistryEntryLastModified: "2021-10-22"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/worldcover.yaml
+++ b/collections/worldcover.yaml
@@ -39,7 +39,7 @@ LicenseType: proprietary
 LicenseUrl: https://creativecommons.org/licenses/by/4.0/
 Resources:
   - Group: Sentinel Hub Resources
-    EndPoint: services.sentinel-hub.com
+    EndPoint: https://services.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
     Type: byoc-0b940c63-45dd-4e6b-8019-c3660b81b884

--- a/collections/worldview-geoeye.yaml
+++ b/collections/worldview-geoeye.yaml
@@ -40,4 +40,4 @@ Resources:
     Notes: Contains the data purchased by individual user
 
 RegistryEntryAdded: "2021-04-17"
-RegistryEntryLastModified: "2021-05-05"
+RegistryEntryLastModified: "2022-02-09"

--- a/collections/worldview-geoeye.yaml
+++ b/collections/worldview-geoeye.yaml
@@ -34,7 +34,7 @@ License: |
   [License](https://docs.sentinel-hub.com/api/latest/data/maxar/world-view/#attribution-and-use)
 Resources:
   - Group: Sentinel Hub Resources   
-    EndPoint: services.sentinel-hub.com
+    EndPoint: https://services.sentinel-hub.com
     Type: CUSTOM
     CollectionId: known to user after purchase
     Notes: Contains the data purchased by individual user

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "natives": "^1.1.6",
         "object-path": ">=0.11.5",
         "require-dir": "^0.3.2",
+        "stac-node-validator": "^1.2.2",
         "yaml": "^1.4.0"
       }
     },
@@ -1277,6 +1278,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
+      "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
     },
     "node_modules/ansi-colors": {
       "version": "1.1.0",
@@ -2551,6 +2591,12 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
+    "node_modules/compare-versions": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-4.1.3.tgz",
+      "integrity": "sha512-WQfnbDcrYnGr55UwbxKiQKASnTtNnaAWVi8jZyy8NTpVAXWACSne8lMD1iaIo9AiU6mnuLvSVshCzewVuWxHUg==",
       "dev": true
     },
     "node_modules/component-bind": {
@@ -3846,9 +3892,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
-      "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==",
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
       "dev": true,
       "funding": [
         {
@@ -7216,6 +7262,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/klaw": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-4.0.1.tgz",
+      "integrity": "sha512-pgsE40/SvC7st04AHiISNewaIMUbY5V/K8b21ekiPiFoYs/EYSdsGa+FJArB1d441uq4Q8zZyIxvAzkGNlBdRw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.14.0"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -9153,6 +9208,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-glob": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/require-glob/-/require-glob-3.2.0.tgz",
@@ -10170,6 +10234,202 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stac-node-validator": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/stac-node-validator/-/stac-node-validator-1.2.2.tgz",
+      "integrity": "sha512-H11fFpoODxusHU2N5gIJJRjth9AuDMyRaMyEWmxFYRypPviW4wTzVIOFnlczV1ktIxUgxNHHbMy31XH0kLwUJg==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^8.8.2",
+        "ajv-formats": "^2.1.1",
+        "axios": "^0.24.0",
+        "compare-versions": "^4.1.1",
+        "fs-extra": "^10.0.0",
+        "jest-diff": "^27.4.0",
+        "klaw": "^4.0.1",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "stac-node-validator": "bin/cli.js"
+      }
+    },
+    "node_modules/stac-node-validator/node_modules/ajv": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
+      "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/stac-node-validator/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stac-node-validator/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/stac-node-validator/node_modules/axios": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.14.4"
+      }
+    },
+    "node_modules/stac-node-validator/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/stac-node-validator/node_modules/diff-sequences": {
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.4.0.tgz",
+      "integrity": "sha512-YqiQzkrsmHMH5uuh8OdQFU9/ZpADnwzml8z0O5HvRNda+5UZsaX/xN+AAxfR2hWq1Y7HZnAzO9J5lJXOuDz2Ww==",
+      "dev": true,
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/stac-node-validator/node_modules/fs-extra": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/stac-node-validator/node_modules/jest-diff": {
+      "version": "27.4.6",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.4.6.tgz",
+      "integrity": "sha512-zjaB0sh0Lb13VyPsd92V7HkqF6yKRH9vm33rwBt7rPYrpQvS1nCvlIy2pICbKta+ZjWngYLNn4cCK4nyZkjS/w==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^27.4.0",
+        "jest-get-type": "^27.4.0",
+        "pretty-format": "^27.4.6"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/stac-node-validator/node_modules/jest-get-type": {
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.4.0.tgz",
+      "integrity": "sha512-tk9o+ld5TWq41DkK14L4wox4s2D9MtTpKaAVzXfr5CUKm5ZK2ExcaFE0qls2W71zE/6R2TxxrK9w2r6svAFDBQ==",
+      "dev": true,
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/stac-node-validator/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
+    "node_modules/stac-node-validator/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/stac-node-validator/node_modules/pretty-format": {
+      "version": "27.4.6",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.6.tgz",
+      "integrity": "sha512-NblstegA1y/RJW2VyML+3LlpFjzx62cUrtBIKIWDXEDkjNeleA7Od7nrzcs/VLQvAeV4CgSYhrN39DRN88Qi/g==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/stac-node-validator/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/stac-node-validator/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stac-node-validator/node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/stack-trace": {
@@ -12469,6 +12729,35 @@
         "uri-js": "^4.2.2"
       }
     },
+    "ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^8.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.9.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
+          "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        }
+      }
+    },
     "ansi-colors": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
@@ -13480,6 +13769,12 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
+    "compare-versions": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-4.1.3.tgz",
+      "integrity": "sha512-WQfnbDcrYnGr55UwbxKiQKASnTtNnaAWVi8jZyy8NTpVAXWACSne8lMD1iaIo9AiU6mnuLvSVshCzewVuWxHUg==",
       "dev": true
     },
     "component-bind": {
@@ -14567,9 +14862,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
-      "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==",
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
       "dev": true
     },
     "for-in": {
@@ -17172,6 +17467,12 @@
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
+    "klaw": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-4.0.1.tgz",
+      "integrity": "sha512-pgsE40/SvC7st04AHiISNewaIMUbY5V/K8b21ekiPiFoYs/EYSdsGa+FJArB1d441uq4Q8zZyIxvAzkGNlBdRw==",
+      "dev": true
+    },
     "kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -18686,6 +18987,12 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true
+    },
     "require-glob": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/require-glob/-/require-glob-3.2.0.tgz",
@@ -19566,6 +19873,155 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
+      }
+    },
+    "stac-node-validator": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/stac-node-validator/-/stac-node-validator-1.2.2.tgz",
+      "integrity": "sha512-H11fFpoODxusHU2N5gIJJRjth9AuDMyRaMyEWmxFYRypPviW4wTzVIOFnlczV1ktIxUgxNHHbMy31XH0kLwUJg==",
+      "dev": true,
+      "requires": {
+        "ajv": "^8.8.2",
+        "ajv-formats": "^2.1.1",
+        "axios": "^0.24.0",
+        "compare-versions": "^4.1.1",
+        "fs-extra": "^10.0.0",
+        "jest-diff": "^27.4.0",
+        "klaw": "^4.0.1",
+        "minimist": "^1.2.5"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.9.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
+          "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "axios": {
+          "version": "0.24.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+          "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.14.4"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "diff-sequences": {
+          "version": "27.4.0",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.4.0.tgz",
+          "integrity": "sha512-YqiQzkrsmHMH5uuh8OdQFU9/ZpADnwzml8z0O5HvRNda+5UZsaX/xN+AAxfR2hWq1Y7HZnAzO9J5lJXOuDz2Ww==",
+          "dev": true
+        },
+        "fs-extra": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+          "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "jest-diff": {
+          "version": "27.4.6",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.4.6.tgz",
+          "integrity": "sha512-zjaB0sh0Lb13VyPsd92V7HkqF6yKRH9vm33rwBt7rPYrpQvS1nCvlIy2pICbKta+ZjWngYLNn4cCK4nyZkjS/w==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "diff-sequences": "^27.4.0",
+            "jest-get-type": "^27.4.0",
+            "pretty-format": "^27.4.6"
+          }
+        },
+        "jest-get-type": {
+          "version": "27.4.0",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.4.0.tgz",
+          "integrity": "sha512-tk9o+ld5TWq41DkK14L4wox4s2D9MtTpKaAVzXfr5CUKm5ZK2ExcaFE0qls2W71zE/6R2TxxrK9w2r6svAFDBQ==",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
+        "pretty-format": {
+          "version": "27.4.6",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.6.tgz",
+          "integrity": "sha512-NblstegA1y/RJW2VyML+3LlpFjzx62cUrtBIKIWDXEDkjNeleA7Od7nrzcs/VLQvAeV4CgSYhrN39DRN88Qi/g==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^17.0.1"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+              "dev": true
+            }
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+          "dev": true
+        }
       }
     },
     "stack-trace": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "postinstall": "husky install",
     "build": "./node_modules/gulp-cli/bin/gulp.js",
     "serve": "./node_modules/gulp-cli/bin/gulp.js serve",
-    "test": "jest"
+    "test": "jest",
+    "test-stac": "npx stac-node-validator ./_output/stac/*.json"
   },
   "author": "Joe Flasher",
   "license": "Apache-2.0",
@@ -30,6 +31,7 @@
     "natives": "^1.1.6",
     "object-path": ">=0.11.5",
     "require-dir": "^0.3.2",
+    "stac-node-validator": "^1.2.2",
     "yaml": "^1.4.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "postinstall": "husky install",
     "build": "./node_modules/gulp-cli/bin/gulp.js",
     "serve": "./node_modules/gulp-cli/bin/gulp.js serve",
-    "test": "jest",
-    "test-stac": "npx stac-node-validator ./_output/stac/*.json"
+    "test": "npm run build && jest",
+    "test-stac": "npm run build && npx stac-node-validator ./_output/stac/*.json"
   },
   "author": "Joe Flasher",
   "license": "Apache-2.0",


### PR DESCRIPTION
- added npm script for checking validity of stac json files with [`stac-node-validator`](https://www.npmjs.com/package/stac-node-validator)
  - executed by running `npm run test-stac`
  - not part of the husky pre-commit hook yet because a lot of files are still invalid
- _[point 1 in internal issue]_ added the protocol (`https://`) to the `Endpoint` URL under `Resources` in yaml files (gets transformed to `url` in elements in `providers` in stac json files)
- _[point 3 in internal issue]_ updated the PROJJSON schema from v0.2 to v0.4
- _[point 5 in internal issue]_ replaced `eo:gsd` with `gsd`
- _[point 6 in internal issue]_ changed `stac.hbs` so it adds `title` and `type` to the License `link` object in stac json files
  - before: `{ "href": "url...", "rel": "license" }`
  - after: `{ "href": "url...", "rel": "license", "title": "License", "type": "text/html" }`
  - similar as  https://github.com/eurodatacube/public-collections/pull/152 for `eo:bands` and `raster:bands`

[internal issue](https://git.sinergise.com/team-6/openeo-platform/-/issues/47)