### PR TITLE
put warnings:true as an item in wmts:dimensions for L8

### DIFF
--- a/_build/stac.hbs
+++ b/_build/stac.hbs
@@ -40,7 +40,7 @@
       "href": "{{{find WMTS 'href' 'href'}}}",
       "rel": "wmts",
       "wmts:layer": "{{{find WMTS 'layer_id' 'layer_id'}}}",
-      "wmts:dimensions": "{{{find WMTS 'dimensions' 'dimensions'}}}"
+      "wmts:dimensions": {{{copyJson (find WMTS 'dimensions' 'dimensions')}}}
     },
     {{/if}}
 {{#each Configurations}}

--- a/collections/landsat-8-l1.yaml
+++ b/collections/landsat-8-l1.yaml
@@ -47,7 +47,8 @@ Resources:
 WMTS:
   - href: https://services-uswest2.sentinel-hub.com/ogc/wmts/fc306b9b-4448-41d2-922d-6db03b26610e
     layer_id: TRUE-COLOR
-    dimensions: "warnings: true"
+    dimensions: 
+      warnings: true
 CustomScripts:
     Title: Collection of Landsat-8 custom scripts
     URL: https://custom-scripts.sentinel-hub.com/#landsat-8

--- a/collections/landsat-8-l2.yaml
+++ b/collections/landsat-8-l2.yaml
@@ -51,7 +51,8 @@ CustomScripts:
 WMTS:
   - href: https://services-uswest2.sentinel-hub.com/ogc/wmts/2bb342e8-8d2e-4f06-8ed6-b6d7ab65187d
     layer_id: TRUE-COLOR
-    dimensions: "warnings: true"
+    dimensions: 
+      warnings: true
 Configurations:
   - layer_name: True color
     evalscript_url: "https://custom-scripts.sentinel-hub.com/landsat-8/true-color/script.js"


### PR DESCRIPTION
`wmts:dimensions` in stac json files for Landsat-8 L1 and L2 should be an object ` {"warnings": true}` instead of string `"warning: true"`.

current state: [landsat-8 l2 stac json file](https://collections.eurodatacube.com/stac/landsat-8-l2.json)

Ran the build process locally with the result: `"wmts:dimensions": {"warnings":true}`

[internal issue](https://git.sinergise.com/team-6/openeo-platform/-/issues/58)
