### PR TITLE
fix clms-lake-water-quality.yaml

### DIFF
--- a/collections/clms-lake-water-quality.yaml
+++ b/collections/clms-lake-water-quality.yaml
@@ -39,7 +39,7 @@ License: |
   [License](https://land.copernicus.eu/terms-of-usee)
 Resources:
 -  Group: xcube Generator Resources
-   StoreInstanceID: @cop_services_clms
+   StoreInstanceID: "@cop_services_clms"
    StoreTitle: CLMS Copernicus Datasets on S3
    DataID: LWQ-NRT-300m.zarr
 RegistryEntryAdded: "2021-05-13"


### PR DESCRIPTION
`StoreInstanceID` in `collections/clms-lake-water-quality.yaml` starts with the `@` and that causes problems when running `npm run build`.

I wrapped `StoreInstanceID` in quotes to fix the issue.

If you are not sure if some text with special characters would cause problems, you can wrap them in quotes.
Rule of thumb is that the values (text) for the keys in yaml files can be wrapped in quotes - it shouldn't do any harm.

```yaml
key: "value"
# or
- key: "value"
```
