### PR TITLE
make temporal availability in s5p-tropno array

### DIFF
--- a/collections/s5p-no2-tropno-daily-check.yaml
+++ b/collections/s5p-no2-tropno-daily-check.yaml
@@ -49,6 +49,7 @@ Extent:
         - 90
   temporal:
     interval:
+      -
         - '2018-04-30T00:18:50Z'
         - null
 CubeDimensions:


### PR DESCRIPTION
This interval is showing up as two different arrays in EDC Browser. I assume it's supposed to be `[date, null]` instead since the first one doesn't have an end date? 

<img width="314" alt="Screenshot 2022-03-11 at 09 41 17" src="https://user-images.githubusercontent.com/49114004/157832655-3ac6999c-7cfc-4112-ae2e-898187a9bdc4.png">
