### PR TITLE
set back temporal extent cop dem

### DIFF
--- a/collections/copernicus-dem.yaml
+++ b/collections/copernicus-dem.yaml
@@ -100,8 +100,8 @@ Extent:
   temporal:
     interval:
       -
-        - null
-        - null
+        - '2010-12-12T05:04:33Z'
+        - '2015-01-16T01:37:12Z'
 CubeDimensions:
   x:
     type: spatial
@@ -120,8 +120,8 @@ CubeDimensions:
   t:
     type: temporal
     extent:
-      - null
-      - null
+      - '2010-12-12T05:04:33Z'
+      - '2015-01-16T01:37:12Z'
   bands:
     type: bands
     values:
@@ -139,4 +139,4 @@ Summaries:
     - description: The mask of data/no data pixels.
       name: dataMask
 RegistryEntryAdded: "2020-11-30"
-RegistryEntryLastModified: "2022-07-12"
+RegistryEntryLastModified: "2022-07-18"


### PR DESCRIPTION
Having [ null , null] as temporal extend causes the EDC Browser to not load any collections. This resets the temporal extend until the issue is fixed.