### PR TITLE
Add reference to the public collections website

### DIFF
--- a/_build/stac.hbs
+++ b/_build/stac.hbs
@@ -36,7 +36,7 @@
       "rel": "self"
     },
     {
-      "href": "{{rootUrl}}/{{Slug}}",
+      "href": "{{rootUrl}}{{Slug}}",
       "rel": "about",
       "type": "text/html",
       "title": "Website describing the collection"

--- a/_build/stac.hbs
+++ b/_build/stac.hbs
@@ -35,6 +35,12 @@
       "href": "{{rootUrl}}stac/{{Slug}}.json",
       "rel": "self"
     },
+    {
+      "href": "{{rootUrl}}/{{Slug}}",
+      "rel": "about",
+      "type": "text/html",
+      "title": "Website describing the collection"
+    },
     {{#if WMTS }}    
     {
       "href": "{{{find WMTS 'href' 'href'}}}",


### PR DESCRIPTION
This PR:

- Adds reference to the public collections website by generating it in the `stac.hbs`.

Closes this [issue](https://git.sinergise.com/team-6/openeo-platform/-/issues/191).