### PR TITLE
Add legend info to public collections link object

### DIFF
--- a/collections/cnes-land-cover-map.yaml
+++ b/collections/cnes-land-cover-map.yaml
@@ -82,7 +82,7 @@ DocumentationLinks:
   - href: "https://collections.eurodatacube.com/cnes-land-cover-map/readme.html#band-information"
     rel: "about"
     type: "text/html"
-    title: "Nomenclature mapping - band values CNES Land Cover Map labels - Legend used for 2020, 2019 and 2018 data"    
+    title: "Nomenclature mapping - band values CNES Land Cover Map labels - Legend used for 2020, 2019 and 2018 data"
 Extent:
   spatial:
     bbox:

--- a/collections/cnes-land-cover-map.yaml
+++ b/collections/cnes-land-cover-map.yaml
@@ -78,6 +78,11 @@ Configurations:
     sentinelhub:layer_name: "CNES Land Cover Validity"
     sentinelhub:mosaicking_order: "mostRecent"
     sentinelhub:upsampling: "BICUBIC"
+DocumentationLinks:
+  - href: "https://collections.eurodatacube.com/cnes-land-cover-map/readme.html#band-information"
+    rel: "about"
+    type: "text/html"
+    title: "Nomenclature mapping - band values CNES Land Cover Map labels - Legend used for 2020, 2019 and 2018 data"    
 Extent:
   spatial:
     bbox:
@@ -116,4 +121,4 @@ CubeDimensions:
       - OCS_Confidence
       - OCS_Validity
 RegistryEntryAdded: "2022-02-24"
-RegistryEntryLastModified: "2022-07-06"
+RegistryEntryLastModified: "2022-07-25"

--- a/collections/global-land-cover.yaml
+++ b/collections/global-land-cover.yaml
@@ -102,6 +102,11 @@ Configurations:
     sentinelhub:layer_name: "Discrete Classification Map"
     sentinelhub:mosaicking_order: "mostRecent"
     sentinelhub:upsampling: "BICUBIC"
+DocumentationLinks:
+  - href: "https://collections.eurodatacube.com/global-land-cover/readme.html#band-information)"
+    rel: "about"
+    type: "text/html"
+    title: "Nomenclature mapping - band values Global Land Cover labels"    
 Extent:
   spatial:
     bbox:
@@ -265,4 +270,4 @@ Summaries:
     - description: The mask of data/no data pixels.
       name: dataMask
 RegistryEntryAdded: "2021-03-20"
-RegistryEntryLastModified: "2022-07-04"
+RegistryEntryLastModified: "2022-07-25"

--- a/collections/global-land-cover.yaml
+++ b/collections/global-land-cover.yaml
@@ -103,10 +103,10 @@ Configurations:
     sentinelhub:mosaicking_order: "mostRecent"
     sentinelhub:upsampling: "BICUBIC"
 DocumentationLinks:
-  - href: "https://collections.eurodatacube.com/global-land-cover/readme.html#band-information)"
+  - href: "https://collections.eurodatacube.com/global-land-cover/readme.html#band-information"
     rel: "about"
     type: "text/html"
-    title: "Nomenclature mapping - band values Global Land Cover labels"    
+    title: "Nomenclature mapping - band values Global Land Cover labels"
 Extent:
   spatial:
     bbox:

--- a/collections/global-surface-water.yaml
+++ b/collections/global-surface-water.yaml
@@ -114,6 +114,11 @@ Configurations:
     sentinelhub:layer_name: "Global Surface Water Extent"
     sentinelhub:mosaicking_order: "mostRecent"
     sentinelhub:upsampling: "BICUBIC"
+DocumentationLinks:
+  - href: "https://collections.eurodatacube.com/global-surface-water/readme.html#band-information"
+    rel: "about"
+    type: "text/html"
+    title: "Nomenclature mapping - band values Global Surface Water labels"    
 Extent:
   spatial:
     bbox:
@@ -204,4 +209,4 @@ Summaries:
     - description: The mask of data/no data pixels.
       name: dataMask
 RegistryEntryAdded: "2021-04-19"
-RegistryEntryLastModified: "2022-07-04"
+RegistryEntryLastModified: "2022-07-25"

--- a/collections/water-bodies.yaml
+++ b/collections/water-bodies.yaml
@@ -84,7 +84,7 @@ DocumentationLinks:
   - href: "https://collections.eurodatacube.com/water-bodies/readme.html#band-information"
     rel: "about"
     type: "text/html"
-    title: "Nomenclature mapping - band values Water Bodies labels"    
+    title: "Nomenclature mapping - band values Water Bodies labels"
 Extent:
   spatial:
     bbox:

--- a/collections/water-bodies.yaml
+++ b/collections/water-bodies.yaml
@@ -80,6 +80,11 @@ Configurations:
     sentinelhub:layer_name: "Water Bodies Occurrence"
     sentinelhub:mosaicking_order: "mostRecent"
     sentinelhub:upsampling: "BICUBIC"
+DocumentationLinks:
+  - href: "https://collections.eurodatacube.com/water-bodies/readme.html#band-information"
+    rel: "about"
+    type: "text/html"
+    title: "Nomenclature mapping - band values Water Bodies labels"    
 Extent:
   spatial:
     bbox:
@@ -139,4 +144,4 @@ Summaries:
     - description: The mask of data/no data pixels.
       name: dataMask
 RegistryEntryAdded: "2021-03-30"
-RegistryEntryLastModified: "2022-07-04"
+RegistryEntryLastModified: "2022-07-25"

--- a/collections/worldcover.yaml
+++ b/collections/worldcover.yaml
@@ -66,7 +66,7 @@ DocumentationLinks:
   - href: "https://collections.eurodatacube.com/worldcover/readme.html#band-information"
     rel: "about"
     type: "text/html"
-    title: "Nomenclature mapping - band values WorldCover labels"    
+    title: "Nomenclature mapping - band values WorldCover labels"
 Extent:
   spatial:
     bbox:

--- a/collections/worldcover.yaml
+++ b/collections/worldcover.yaml
@@ -62,6 +62,11 @@ Configurations:
     sentinelhub:layer_name: "ESA WorldCover Map"
     sentinelhub:mosaicking_order: "mostRecent"
     sentinelhub:upsampling: "BICUBIC"
+DocumentationLinks:
+  - href: "https://collections.eurodatacube.com/worldcover/readme.html#band-information"
+    rel: "about"
+    type: "text/html"
+    title: "Nomenclature mapping - band values WorldCover labels"    
 Extent:
   spatial:
     bbox:
@@ -99,4 +104,4 @@ CubeDimensions:
       - Map
       - dataMask
 RegistryEntryAdded: "2021-10-19"
-RegistryEntryLastModified: "2022-07-04"
+RegistryEntryLastModified: "2022-07-25"


### PR DESCRIPTION
This PR:
- Adds legend info to public collections link object - `DocumentationLinks:` for the following collections:

  - CNES Land Cover Map
  - ESA World Cover
  - Global Land Cover
  - Global Surface Water
  - Water Bodies

Closes this [issue](https://git.sinergise.com/team-6/openeo-platform/-/issues/192).
