### PR TITLE
Add S3-SLSTR filter extension options to collection metadata

### DIFF
--- a/collections/sentinel-2-l1c.yaml
+++ b/collections/sentinel-2-l1c.yaml
@@ -418,6 +418,9 @@ Summaries:
     - 60
   instruments:
     - msi
+  eo:cloud_cover:
+    - 0
+    - 100
   platform:
     - sentinel-2a
     - sentinel-2b
@@ -564,4 +567,4 @@ CRS:
   - "http://www.opengis.net/def/crs/EPSG/0/32760"
   - "http://www.opengis.net/def/crs/SR-ORG/0/98739"
 RegistryEntryAdded: "2018-04-17"
-RegistryEntryLastModified: "2022-07-04"
+RegistryEntryLastModified: "2022-07-27"

--- a/collections/sentinel-2-l2a.yaml
+++ b/collections/sentinel-2-l2a.yaml
@@ -438,6 +438,9 @@ Summaries:
     - 60
   instruments:
     - msi
+  eo:cloud_cover:
+    - 0
+    - 100
   platform:
     - sentinel-2a
     - sentinel-2b
@@ -584,4 +587,4 @@ CRS:
   - "http://www.opengis.net/def/crs/EPSG/0/32760"
   - "http://www.opengis.net/def/crs/SR-ORG/0/98739"
 RegistryEntryAdded: '2018-04-17'
-RegistryEntryLastModified: "2022-07-04"
+RegistryEntryLastModified: "2022-07-27"

--- a/collections/sentinel-3-l1b-slstr.yaml
+++ b/collections/sentinel-3-l1b-slstr.yaml
@@ -243,6 +243,9 @@ Summaries:
   gsd:
     - 500
     - 1000
+  eo:cloud_cover:
+    - 0
+    - 100
   platform:
     - sentinel-3a
     - sentinel-3b
@@ -389,4 +392,4 @@ CRS:
   - "http://www.opengis.net/def/crs/EPSG/0/32760"
   - "http://www.opengis.net/def/crs/SR-ORG/0/98739"
 RegistryEntryAdded: "2018-04-17"
-RegistryEntryLastModified: "2022-07-04"
+RegistryEntryLastModified: "2022-07-27"


### PR DESCRIPTION
This PR:
- Adds `eo:cloud_cover` to the collection metadata of Sentinel-3 SLSTR L1B.
- Adds `eo:cloud_cover` to the collection metadata of Sentinel-2 L1C, Sentinel-2 L2A.

Closes [issue](https://github.com/openEOPlatform/architecture-docs/issues/259).
