### PR TITLE
Change eo:cloud_cover from array to range object

### DIFF
--- a/collections/landsat-1-5-mss-l1.yaml
+++ b/collections/landsat-1-5-mss-l1.yaml
@@ -256,8 +256,8 @@ Summaries:
     - description: The mask of data/no data pixels.
       name: dataMask
   eo:cloud_cover:
-    - 0
-    - 100
+    minimum: 0
+    maximum: 100
   platform:
     - landsat-1
     - landsat-2
@@ -407,4 +407,4 @@ CRS:
   - "http://www.opengis.net/def/crs/EPSG/0/32760"
   - "http://www.opengis.net/def/crs/SR-ORG/0/98739"
 RegistryEntryAdded: "2021-07-16"
-RegistryEntryLastModified: "2022-07-04"
+RegistryEntryLastModified: "2022-09-21"

--- a/collections/landsat-4-5-tm-l1.yaml
+++ b/collections/landsat-4-5-tm-l1.yaml
@@ -336,8 +336,8 @@ Summaries:
     - description: The mask of data/no data pixels.
       name: dataMask
   eo:cloud_cover:
-    - 0
-    - 100
+    minimum: 0
+    maximum: 100
   gsd:
     - 30
   platform:
@@ -486,4 +486,4 @@ CRS:
   - "http://www.opengis.net/def/crs/EPSG/0/32760"
   - "http://www.opengis.net/def/crs/SR-ORG/0/98739"
 RegistryEntryAdded: "2021-05-12"
-RegistryEntryLastModified: "2022-07-04"
+RegistryEntryLastModified: "2022-09-21"

--- a/collections/landsat-4-5-tm-l2.yaml
+++ b/collections/landsat-4-5-tm-l2.yaml
@@ -385,8 +385,8 @@ Summaries:
     - description: The mask of data/no data pixels.
       name: dataMask
   eo:cloud_cover:
-    - 0
-    - 100
+    minimum: 0
+    maximum: 100
   gsd:
     - 30
   platform:
@@ -535,4 +535,4 @@ CRS:
   - "http://www.opengis.net/def/crs/EPSG/0/32760"
   - "http://www.opengis.net/def/crs/SR-ORG/0/98739"
 RegistryEntryAdded: "2021-05-12"
-RegistryEntryLastModified: "2022-07-04"
+RegistryEntryLastModified: "2022-09-21"

--- a/collections/landsat-7-etm+-l1.yaml
+++ b/collections/landsat-7-etm+-l1.yaml
@@ -354,8 +354,8 @@ Summaries:
     - description: The mask of data/no data pixels.
       name: dataMask
   eo:cloud_cover:
-    - 0
-    - 100
+    minimum: 0
+    maximum: 100
   platform:
     - landsat-7
 CRS:
@@ -501,4 +501,4 @@ CRS:
   - "http://www.opengis.net/def/crs/EPSG/0/32760"
   - "http://www.opengis.net/def/crs/SR-ORG/0/98739"
 RegistryEntryAdded: "2021-07-16"
-RegistryEntryLastModified: "2022-07-04"
+RegistryEntryLastModified: "2022-09-21"

--- a/collections/landsat-7-etm+-l2.yaml
+++ b/collections/landsat-7-etm+-l2.yaml
@@ -387,8 +387,8 @@ Summaries:
     - description: The mask of data/no data pixels.
       name: dataMask
   eo:cloud_cover:
-    - 0
-    - 100
+    minimum: 0
+    maximum: 100
   platform:
     - landsat-7
 CRS:
@@ -534,4 +534,4 @@ CRS:
   - "http://www.opengis.net/def/crs/EPSG/0/32760"
   - "http://www.opengis.net/def/crs/SR-ORG/0/98739"
 RegistryEntryAdded: "2021-07-16"
-RegistryEntryLastModified: "2022-07-04"
+RegistryEntryLastModified: "2022-09-21"

--- a/collections/landsat-8-l1.yaml
+++ b/collections/landsat-8-l1.yaml
@@ -398,8 +398,8 @@ Summaries:
     - description: The mask of data/no data pixels.
       name: dataMask
   eo:cloud_cover:
-    - 0
-    - 100
+    minimum: 0
+    maximum: 100
   platform:
     - landsat-8
     - landsat-9
@@ -546,4 +546,4 @@ CRS:
   - "http://www.opengis.net/def/crs/EPSG/0/32760"
   - "http://www.opengis.net/def/crs/SR-ORG/0/98739"
 RegistryEntryAdded: "2018-04-17"
-RegistryEntryLastModified: "2022-07-04"
+RegistryEntryLastModified: "2022-09-21"

--- a/collections/landsat-8-l2.yaml
+++ b/collections/landsat-8-l2.yaml
@@ -399,8 +399,8 @@ Summaries:
     - description: The mask of data/no data pixels.
       name: dataMask
   eo:cloud_cover:
-    - 0
-    - 100
+    minimum: 0
+    maximum: 100
   platform:
     - landsat-8
     - landsat-9
@@ -547,4 +547,4 @@ CRS:
   - "http://www.opengis.net/def/crs/EPSG/0/32760"
   - "http://www.opengis.net/def/crs/SR-ORG/0/98739"
 RegistryEntryAdded: "2018-04-17"
-RegistryEntryLastModified: "2022-07-04"
+RegistryEntryLastModified: "2022-09-21"

--- a/collections/sentinel-2-l1c.yaml
+++ b/collections/sentinel-2-l1c.yaml
@@ -419,8 +419,8 @@ Summaries:
   instruments:
     - msi
   eo:cloud_cover:
-    - 0
-    - 100
+    minimum: 0
+    maximum: 100
   platform:
     - sentinel-2a
     - sentinel-2b
@@ -567,4 +567,4 @@ CRS:
   - "http://www.opengis.net/def/crs/EPSG/0/32760"
   - "http://www.opengis.net/def/crs/SR-ORG/0/98739"
 RegistryEntryAdded: "2018-04-17"
-RegistryEntryLastModified: "2022-07-27"
+RegistryEntryLastModified: "2022-09-21"

--- a/collections/sentinel-2-l2a.yaml
+++ b/collections/sentinel-2-l2a.yaml
@@ -439,8 +439,8 @@ Summaries:
   instruments:
     - msi
   eo:cloud_cover:
-    - 0
-    - 100
+    minimum: 0
+    maximum: 100
   platform:
     - sentinel-2a
     - sentinel-2b
@@ -587,4 +587,4 @@ CRS:
   - "http://www.opengis.net/def/crs/EPSG/0/32760"
   - "http://www.opengis.net/def/crs/SR-ORG/0/98739"
 RegistryEntryAdded: '2018-04-17'
-RegistryEntryLastModified: "2022-07-27"
+RegistryEntryLastModified: "2022-09-21"

--- a/collections/sentinel-3-l1b-slstr.yaml
+++ b/collections/sentinel-3-l1b-slstr.yaml
@@ -244,8 +244,8 @@ Summaries:
     - 500
     - 1000
   eo:cloud_cover:
-    - 0
-    - 100
+    minimum: 0
+    maximum: 100
   platform:
     - sentinel-3a
     - sentinel-3b
@@ -392,4 +392,4 @@ CRS:
   - "http://www.opengis.net/def/crs/EPSG/0/32760"
   - "http://www.opengis.net/def/crs/SR-ORG/0/98739"
 RegistryEntryAdded: "2018-04-17"
-RegistryEntryLastModified: "2022-07-27"
+RegistryEntryLastModified: "2022-09-21"


### PR DESCRIPTION
Closes #230 

This MR:
- Changes `eo:cloud_cover` rendering from the array to the range object in `Summaries` of the following collections:

  - `Landsat 1-5 MSS L1`
  - `Landsat 4-5 TM L1, L2`
  - `Landsat 7 ETM+ L1, L2`
  - `Landsat 8-9 L1, L2`
  - `Sentinel-2 L1C, L2A`
  - `Sentinel-3 SLSTR L1B`