### PR TITLE
Add additional bands to the collections metadata

### DIFF
--- a/collections/sentinel-1-grd.yaml
+++ b/collections/sentinel-1-grd.yaml
@@ -176,6 +176,10 @@ Summaries:
     - HV
     - VV
     - VH
+    - localIncidenceAngle
+    - scatteringArea
+    - shadowMask
+    - dataMask
   raster:bands:
     - name: VV
       description: 'Single co-polarization, vertical transmit/vertical receive'
@@ -221,6 +225,15 @@ Summaries:
         - - 0.00037037037
           - 0.00037037037
         unit: °
+    - name: localIncidenceAngle
+      description: 'The local incidence angle for each output pixel'
+        unit: °
+    - name: scatteringArea
+      description: 'The normalized scattering area for each output pixel'
+    - name: shadowMask
+      description: 'Flags output pixels which are in or near radar shadow'
+    - name: dataMask
+      description: 'The mask of data/no data pixels'
 CRS:
   - "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
   - "http://www.opengis.net/def/crs/EPSG/0/2154"
@@ -364,4 +377,4 @@ CRS:
   - "http://www.opengis.net/def/crs/EPSG/0/32760"
   - "http://www.opengis.net/def/crs/SR-ORG/0/98739"
 RegistryEntryAdded: "2018-04-17"
-RegistryEntryLastModified: "2022-07-04"
+RegistryEntryLastModified: "2022-10-25"

--- a/collections/sentinel-1-grd.yaml
+++ b/collections/sentinel-1-grd.yaml
@@ -176,9 +176,6 @@ Summaries:
     - HV
     - VV
     - VH
-    - localIncidenceAngle
-    - scatteringArea
-    - shadowMask
     - dataMask
   raster:bands:
     - name: VV
@@ -225,13 +222,6 @@ Summaries:
         - - 0.00037037037
           - 0.00037037037
         unit: °
-    - name: localIncidenceAngle
-      description: 'The local incidence angle for each output pixel'
-        unit: °
-    - name: scatteringArea
-      description: 'The normalized scattering area for each output pixel'
-    - name: shadowMask
-      description: 'Flags output pixels which are in or near radar shadow'
     - name: dataMask
       description: 'The mask of data/no data pixels'
 CRS:
@@ -377,4 +367,4 @@ CRS:
   - "http://www.opengis.net/def/crs/EPSG/0/32760"
   - "http://www.opengis.net/def/crs/SR-ORG/0/98739"
 RegistryEntryAdded: "2018-04-17"
-RegistryEntryLastModified: "2022-10-25"
+RegistryEntryLastModified: "2022-10-28"

--- a/collections/sentinel-3-l1b-olci.yaml
+++ b/collections/sentinel-3-l1b-olci.yaml
@@ -162,7 +162,6 @@ CubeDimensions:
       - SEA_LEVEL_PRESSURE
       - TOTAL_COLUMN_OZONE
       - TOTAL_COLUMN_WATER_VAPOUR
-      - QUALITY_FLAGS
       - dataMask
 sci:citation: "Modified Copernicus Sentinel data [Year]/Sentinel Hub"
 Summaries:
@@ -414,8 +413,6 @@ Summaries:
           - 0.188492063492033
           - 0.188492063492033
         unit: °
-    - description: Classification and quality flags
-      name: QUALITY_FLAGS
     - description: The mask of data/no data pixels.
       name: dataMask
   gsd:
@@ -566,4 +563,4 @@ CRS:
   - "http://www.opengis.net/def/crs/EPSG/0/32760"
   - "http://www.opengis.net/def/crs/SR-ORG/0/98739"
 RegistryEntryAdded: "2018-04-17"
-RegistryEntryLastModified: "2022-10-25"
+RegistryEntryLastModified: "2022-10-28"

--- a/collections/sentinel-3-l1b-olci.yaml
+++ b/collections/sentinel-3-l1b-olci.yaml
@@ -162,6 +162,7 @@ CubeDimensions:
       - SEA_LEVEL_PRESSURE
       - TOTAL_COLUMN_OZONE
       - TOTAL_COLUMN_WATER_VAPOUR
+      - QUALITY_FLAGS
       - dataMask
 sci:citation: "Modified Copernicus Sentinel data [Year]/Sentinel Hub"
 Summaries:
@@ -410,9 +411,11 @@ Summaries:
       name: TOTAL_COLUMN_WATER_VAPOUR
       openeo:gsd:
         value:
-          - 0.188492063492033 
-          - 0.188492063492033 
+          - 0.188492063492033
+          - 0.188492063492033
         unit: °
+    - description: Classification and quality flags
+      name: QUALITY_FLAGS
     - description: The mask of data/no data pixels.
       name: dataMask
   gsd:
@@ -563,4 +566,4 @@ CRS:
   - "http://www.opengis.net/def/crs/EPSG/0/32760"
   - "http://www.opengis.net/def/crs/SR-ORG/0/98739"
 RegistryEntryAdded: "2018-04-17"
-RegistryEntryLastModified: "2022-07-04"
+RegistryEntryLastModified: "2022-10-25"


### PR DESCRIPTION
Closes #233

This PR:
- Adds additional bands to the metadata of `Sentinel-1 GRD` and `Sentinel-3 OLCI L1B` collections.

Following bands were added:
`localIncidenceAngle`, `scatteringArea`, `shadowMask` and `dataMask` for `Sentinel-1 GRD`;
`QUALITY_FLAGS` for `Sentinel-3 OLCI L1B`.