### PR TITLE
Display correct IDs for openEO collections

### DIFF
--- a/collections/co_3daily_data.yaml
+++ b/collections/co_3daily_data.yaml
@@ -75,10 +75,10 @@ CubeDimensions:
     extent:
       - '2018-04-30T00:00:00Z'
       - null
-    step: P3D
+    step: P1D
   bands:
     type: bands
     values:
       - co
 RegistryEntryAdded: "2022-07-12"
-RegistryEntryLastModified: "2022-12-08"
+RegistryEntryLastModified: "2022-12-09"

--- a/collections/co_3daily_data.yaml
+++ b/collections/co_3daily_data.yaml
@@ -1,4 +1,5 @@
 Name: CO 3daily data
+OpenEOPID: SENTINEL_5P_CO_T3D_AVERAGE
 Description: |
   This online platform uses data from the Copernicus Sentinel-5P satellite and shows the averaged carbon monoxide concentrations across the globe — using a 3-day moving average. Using a 3 day average eliminates most data gaps and improves data quality by reducing random noise. Satellite measurements of concentrations of pollutants like Carbon Monoxide, having a life-time in the atmosphere of about 1 month, can be used to monitor trans-boundary movement of air pollution.
   Carbon monoxide (CO) is a colorless, odorless, and tasteless gas that is toxic to humans as it can disrupt the transport of oxygen by the blood. In the atmosphere, it is spatially variable and has a life-time of about 1 month.
@@ -80,4 +81,4 @@ CubeDimensions:
     values:
       - co
 RegistryEntryAdded: "2022-07-12"
-RegistryEntryLastModified: "2022-07-12"
+RegistryEntryLastModified: "2022-12-08"

--- a/collections/phytoplankton-primary-production.yaml
+++ b/collections/phytoplankton-primary-production.yaml
@@ -25,7 +25,7 @@ Resources:
   - EndPoint: https://services.sentinel-hub.com
     Name: Sentinel Hub
     Role: processor
-    Type: byoc-a216afca-8a65-4072-87a5-8ed7aa21e08a
+    Type: zarr-a216afca-8a65-4072-87a5-8ed7aa21e08a
     CollectionId: a216afca-8a65-4072-87a5-8ed7aa21e08a
     Primary: true
 Configurations:
@@ -53,27 +53,5 @@ Extent:
       -
         - '1998-01-01T00:00:00Z'
         - '2020-12-31T23:59:59'
-CubeDimensions:
-  x:
-    type: spatial
-    axis: x
-    extent:
-      - -180
-      - 180
-  y:
-    type: spatial
-    axis: y
-    extent:
-      - -90
-      - 90
-  t:
-    type: temporal
-    extent:
-      - '1998-01-01T00:00:00Z'
-      - '2020-12-31T23:59:59'
-  bands:
-    type: bands
-    values:
-      - pp
 RegistryEntryAdded: "2022-07-12"
-RegistryEntryLastModified: "2022-07-12"
+RegistryEntryLastModified: "2022-12-08"

--- a/collections/s5p-ch4-weekly.yaml
+++ b/collections/s5p-ch4-weekly.yaml
@@ -1,4 +1,5 @@
 Name: S5P CH4 weekly
+OpenEOPID: SENTINEL_5P_CH4_T7D_AVERAGE
 Description: |
   The data comes from the Copernicus Sentinel-5P satellite and uses data from the Copernicus Sentinel-5P satellite and shows the averaged methane concentrations across the globe — using weekly averaged maps. The methane map shown here is measured by the Tropomi instrument on the Sentinel 5 Precursor satellite.
   The Copernicus Sentinel-5P CH4 measurements were first filtered according to the recommendation in the Product Readme file (only data with a qa_value > 0.50 was used). Then the measurements are mapped on a fixed latitude-longitude grid of 4096 x 8192 pixels. The grid is turned into an EPSG:4326 geotiff file using the appropriate color scale, which is again turned into an EPSG:3857 tile map.
@@ -80,4 +81,4 @@ CubeDimensions:
     values:
       - ch4
 RegistryEntryAdded: "2022-07-12"
-RegistryEntryLastModified: "2022-07-12"
+RegistryEntryLastModified: "2022-12-08"

--- a/collections/s5p-ch4-weekly.yaml
+++ b/collections/s5p-ch4-weekly.yaml
@@ -11,7 +11,7 @@ Image: s5p-ch4-weekly/ch4.PNG
 EDCBrowser: ""
 Resolution: 4.8 x 4.8 Km (across x along track)
 GeographicalCoverage: -180.0, -90.0, 180.0, 90.0
-TemporalAvailability: 2021-11-15 - 2022-06-13
+TemporalAvailability: 2021-11-15 - ongoing
 TemporalResolution: Weekly
 UpdateFrequency: Weekly
 BandInformation: It is made of a single band called "ch4". it is an averaged methane concentrations across the globe — using weekly averaged maps
@@ -56,7 +56,7 @@ Extent:
     interval:
       -
         - '2021-11-15T00:00:00Z'
-        - '2022-06-13T23:59:59Z'
+        - null
 CubeDimensions:
   x:
     type: spatial
@@ -74,11 +74,11 @@ CubeDimensions:
     type: temporal
     extent:
       - '2021-11-15T00:00:00Z'
-      - '2022-06-13T23:59:59Z'
+      - null
     step: P7D
   bands:
     type: bands
     values:
       - ch4
 RegistryEntryAdded: "2022-07-12"
-RegistryEntryLastModified: "2022-12-08"
+RegistryEntryLastModified: "2022-12-12"

--- a/collections/so2_daily_data.yaml
+++ b/collections/so2_daily_data.yaml
@@ -1,5 +1,4 @@
 Name: SO2 daily data
-OpenEOPID: SENTINEL_5P_CH4_T1D
 Description: |
   This online platform uses data from the Copernicus Sentinel-5P satellite and shows the daily sulfur dioxide concentrations coming primarily from volcanic sources. The Copernicus Sentinel-5P SO2 measurements are those retrieved assuming SO2 at an altitude of 7km and explicitly filtering for pixels where a volcanic source is most likely (sulfurdioxide_detection_flag > 0) and where the solar zenith angle is within limits (SZA < 70°). The measurements are then mapped on a fixed latitude-longitude grid of 8193 x 16385 pixels. The grid is turned into an EPSG:4326 geotiff file using the appropriate color scale, which is again turned into an EPSG:3857 tile map.
   Note that for data shown, SO2 from potential anthropogenic sources has not been filtered out, and SO2 from such sources can therefore still show up.
@@ -56,28 +55,5 @@ Extent:
       -
         - '2021-09-19T00:00:00Z'
         - null
-CubeDimensions:
-  x:
-    type: spatial
-    axis: x
-    extent:
-      - -180
-      - 180
-  y:
-    type: spatial
-    axis: y
-    extent:
-      - -90
-      - 90
-  t:
-    type: temporal
-    extent:
-      - '2021-09-19T00:00:00Z'
-      - null
-    step: P1D
-  bands:
-    type: bands
-    values:
-      - so2
 RegistryEntryAdded: "2022-07-12"
-RegistryEntryLastModified: "2022-12-08"
+RegistryEntryLastModified: "2022-12-09"

--- a/collections/so2_daily_data.yaml
+++ b/collections/so2_daily_data.yaml
@@ -1,4 +1,5 @@
 Name: SO2 daily data
+OpenEOPID: SENTINEL_5P_CH4_T1D
 Description: |
   This online platform uses data from the Copernicus Sentinel-5P satellite and shows the daily sulfur dioxide concentrations coming primarily from volcanic sources. The Copernicus Sentinel-5P SO2 measurements are those retrieved assuming SO2 at an altitude of 7km and explicitly filtering for pixels where a volcanic source is most likely (sulfurdioxide_detection_flag > 0) and where the solar zenith angle is within limits (SZA < 70°). The measurements are then mapped on a fixed latitude-longitude grid of 8193 x 16385 pixels. The grid is turned into an EPSG:4326 geotiff file using the appropriate color scale, which is again turned into an EPSG:3857 tile map.
   Note that for data shown, SO2 from potential anthropogenic sources has not been filtered out, and SO2 from such sources can therefore still show up.
@@ -79,4 +80,4 @@ CubeDimensions:
     values:
       - so2
 RegistryEntryAdded: "2022-07-12"
-RegistryEntryLastModified: "2022-07-12"
+RegistryEntryLastModified: "2022-12-08"


### PR DESCRIPTION
Closes #259 

This PR:
- Updates the following collections with the OpenEOPID:
  - `co_3daily_data`
  - `s5p-ch4_weekly`
  - `so2_daily_data`
- Removes `phytoplankton-primary-production` from the index endpoint