### PR TITLE
Remove stac metadata from zarr collections

### DIFF
--- a/collections/pni.yaml
+++ b/collections/pni.yaml
@@ -2,7 +2,7 @@ Name: Percent of Normal Index (PNI)
 Description: Percent of Normal Index (PNI) is calculated by dividing actual precipitation (for the previous 30 or 90 days) by normal precipitation for the time being considered (1991-2020) and multiplying by 100.
 Documentation: "[Climate Indices](https://climate-indices.readthedocs.io/en/latest/#), [Percentage of Normal Precipitation](https://www.droughtmanagement.info/percent-of-normal-precipitation/)"
 Image: pni/thumbnail.png
-EDCBrowser: "https://browser.eurodatacube.com/?zoom=8&lat=47.13454&lng=18.75696&collectionId=LTK_Percent_of_Normal_Index&layerId=Percent%20of%20Normal%20Index&type=sentinel-hub-edc&fromTime=2022-08-01T00%3A00%3A00.000Z&toTime=2022-08-01T23%3A59%3A59.999Z"
+#EDCBrowser: "https://browser.eurodatacube.com/?zoom=8&lat=47.13454&lng=18.75696&collectionId=LTK_Percent_of_Normal_Index&layerId=Percent%20of%20Normal%20Index&type=sentinel-hub-edc&fromTime=2022-08-01T00%3A00%3A00.000Z&toTime=2022-08-01T23%3A59%3A59.999Z"
 Resolution: "0.11°"
 GeographicalCoverage: "Hungary (16.0°, 45.0°, 23.0°, 49.0°)"
 TemporalAvailability: "1971-01-01 - Ongoing"

--- a/collections/pni.yaml
+++ b/collections/pni.yaml
@@ -1,5 +1,4 @@
 Name: Percent of Normal Index (PNI)
-OpenEOPID: "LTK_Percent_of_Normal_Index"
 Description: Percent of Normal Index (PNI) is calculated by dividing actual precipitation (for the previous 30 or 90 days) by normal precipitation for the time being considered (1991-2020) and multiplying by 100.
 Documentation: "[Climate Indices](https://climate-indices.readthedocs.io/en/latest/#), [Percentage of Normal Precipitation](https://www.droughtmanagement.info/percent-of-normal-precipitation/)"
 Image: pni/thumbnail.png

--- a/collections/pni.yaml
+++ b/collections/pni.yaml
@@ -77,34 +77,34 @@ Extent:
       -
         - '1971-01-01T00:00:00Z'
         - null
-CubeDimensions:
-  x:
-    type: spatial
-    axis: x
-    extent:
-      - 16
-      - 23
-  y:
-    type: spatial
-    axis: y
-    extent:
-      - 45
-      - 49
-  t:
-    type: temporal
-    extent:
-      - '1971-01-01T00:00:00Z'
-      - null
-    step: P1M
-  bands:
-    type: bands
-    values:
-      - PNI_1MS
-      - PNI_2MS
-      - PNI_3MS
-      - PNI_6MS
-      - PNI_9MS
-      - PNI_12MS
-      - PNI_24MS
+#CubeDimensions:
+#  x:
+#    type: spatial
+#    axis: x
+#    extent:
+#      - 16
+#      - 23
+#  y:
+#    type: spatial
+#    axis: y
+#    extent:
+#      - 45
+#      - 49
+#  t:
+#    type: temporal
+#    extent:
+#      - '1971-01-01T00:00:00Z'
+#     - null
+#    step: P1M
+#  bands:
+#    type: bands
+#   values:
+#      - PNI_1MS
+#      - PNI_2MS
+#      - PNI_3MS
+#      - PNI_6MS
+#      - PNI_9MS
+#     - PNI_12MS
+#      - PNI_24MS
 RegistryEntryAdded: "2022-11-30"
-RegistryEntryLastModified: "2022-12-05"  
+RegistryEntryLastModified: "2022-12-19"  

--- a/collections/pni.yaml
+++ b/collections/pni.yaml
@@ -1,4 +1,5 @@
 Name: Percent of Normal Index (PNI)
+#OpenEOPID: "LTK_Percent_of_Normal_Index"
 Description: Percent of Normal Index (PNI) is calculated by dividing actual precipitation (for the previous 30 or 90 days) by normal precipitation for the time being considered (1991-2020) and multiplying by 100.
 Documentation: "[Climate Indices](https://climate-indices.readthedocs.io/en/latest/#), [Percentage of Normal Precipitation](https://www.droughtmanagement.info/percent-of-normal-precipitation/)"
 Image: pni/thumbnail.png

--- a/collections/spei.yaml
+++ b/collections/spei.yaml
@@ -1,9 +1,9 @@
 Name: Standard Precipitation Evapotranspiration Index (SPEI)
-OpenEOPID: "LTK_Standard_Precipitation_Evapotranspiration_Index"
+#OpenEOPID: "LTK_Standard_Precipitation_Evapotranspiration_Index"
 Description: Standard Precipitation Evapotranspiration Index (SPEI) uses the basis of [Standard Precipitation Index](https://collections.eurodatacube.com/spi/) but includes a temperature component, allowing the index to account for the effect of temperature on drought development through a basic water balance calculation.
 Documentation: "[Climate Indices](https://climate-indices.readthedocs.io/en/latest/#), [SPEI](https://climatedataguide.ucar.edu/climate-data/standardized-precipitation-evapotranspiration-index-spei)"
 Image: spei/thumbnail.png
-EDCBrowser: "https://browser.eurodatacube.com/?zoom=8&lat=47.13454&lng=18.75696&collectionId=LTK_Standard_Precipitation_Evapotranspiration_Index&layerId=Standard%20Precipitation%20Evapotranspiration%20Index&type=sentinel-hub-edc&fromTime=2022-07-31T22%3A00%3A00.000Z&toTime=2022-08-01T21%3A59%3A59.999Z"
+#EDCBrowser: "https://browser.eurodatacube.com/?zoom=8&lat=47.13454&lng=18.75696&collectionId=LTK_Standard_Precipitation_Evapotranspiration_Index&layerId=Standard%20Precipitation%20Evapotranspiration%20Index&type=sentinel-hub-edc&fromTime=2022-07-31T22%3A00%3A00.000Z&toTime=2022-08-01T21%3A59%3A59.999Z"
 Resolution: "0.11°"
 GeographicalCoverage: "Hungary (16.0°, 45.0°, 23.0°, 49.0°)"
 TemporalAvailability: "1971-01-01 - Ongoing"
@@ -78,34 +78,34 @@ Extent:
       -
         - '1971-01-01T00:00:00Z'
         - null
-CubeDimensions:
-  x:
-    type: spatial
-    axis: x
-    extent:
-      - 16
-      - 23
-  y:
-    type: spatial
-    axis: y
-    extent:
-      - 45
-      - 49
-  t:
-    type: temporal
-    extent:
-      - '1971-01-01T00:00:00Z'
-      - null
-    step: P1M
-  bands:
-    type: bands
-    values:
-      - SPEI_1MS
-      - SPEI_2MS
-      - SPEI_3MS
-      - SPEI_6MS
-      - SPEI_9MS
-      - SPEI_12MS
-      - SPEI_24MS
+#CubeDimensions:
+#  x:
+#    type: spatial
+#    axis: x
+#    extent:
+#      - 16
+#      - 23
+#  y:
+#    type: spatial
+#    axis: y
+#    extent:
+#      - 45
+#      - 49
+#  t:
+#    type: temporal
+#    extent:
+#      - '1971-01-01T00:00:00Z'
+#      - null
+#    step: P1M
+#  bands:
+#    type: bands
+#    values:
+#      - SPEI_1MS
+#      - SPEI_2MS
+#      - SPEI_3MS
+#      - SPEI_6MS
+#      - SPEI_9MS
+#      - SPEI_12MS
+#      - SPEI_24MS
 RegistryEntryAdded: "2022-11-30"
-RegistryEntryLastModified: "2022-12-05"  
+RegistryEntryLastModified: "2022-12-19"  

--- a/collections/spi.yaml
+++ b/collections/spi.yaml
@@ -1,9 +1,9 @@
 Name: Standard Precipitation Index (SPI)
-OpenEOPID: "LTK_Standard_Precipitation_Index"
+#OpenEOPID: "LTK_Standard_Precipitation_Index"
 Description: Standard Precipitation Index (SPI) quantifies observed precipitation as a standardized departure from a selected probability distribution function that models the raw precipitation data. The raw precipitation data are typically fitted to a gamma or a Pearson Type III distribution, and then transformed to a normal distribution.
 Documentation: "[Climate Indices](https://climate-indices.readthedocs.io/en/latest/#), [SPI](https://climatedataguide.ucar.edu/climate-data/standardized-precipitation-index-spi)"
 Image: spi/thumbnail.png
-EDCBrowser: "https://browser.eurodatacube.com/?zoom=8&lat=47.13414&lng=18.75916&collectionId=LTK_Standard_Precipitation_Index&layerId=Standard%20Precipitation%20Index&type=sentinel-hub-edc&fromTime=2022-09-01T00%3A00%3A00.000Z&toTime=2022-09-01T23%3A59%3A59.999Z"
+#EDCBrowser: "https://browser.eurodatacube.com/?zoom=8&lat=47.13414&lng=18.75916&collectionId=LTK_Standard_Precipitation_Index&layerId=Standard%20Precipitation%20Index&type=sentinel-hub-edc&fromTime=2022-09-01T00%3A00%3A00.000Z&toTime=2022-09-01T23%3A59%3A59.999Z"
 Resolution: "0.11°"
 GeographicalCoverage: "Hungary (16.0°, 45.0°, 23.0°, 49.0°)"
 TemporalAvailability: "1971-01-01 -Ongoing"
@@ -78,34 +78,34 @@ Extent:
       -
         - '1971-01-01T00:00:00Z'
         - null
-CubeDimensions:
-  x:
-    type: spatial
-    axis: x
-    extent:
-      - 16
-      - 23
-  y:
-    type: spatial
-    axis: y
-    extent:
-      - 45
-      - 49
-  t:
-    type: temporal
-    extent:
-      - '1971-01-01T00:00:00Z'
-      - null
-    step: P1M
-  bands:
-    type: bands
-    values:
-      - SPI_1MS
-      - SPI_2MS
-      - SPI_3MS
-      - SPI_6MS
-      - SPI_9MS
-      - SPI_12MS
-      - SPI_24MS
+#CubeDimensions:
+#  x:
+#    type: spatial
+#    axis: x
+#    extent:
+#      - 16
+#      - 23
+#  y:
+#    type: spatial
+#    axis: y
+#    extent:
+#      - 45
+#      - 49
+#  t:
+#    type: temporal
+#    extent:
+#      - '1971-01-01T00:00:00Z'
+#      - null
+#    step: P1M
+#  bands:
+#    type: bands
+#    values:
+#      - SPI_1MS
+#      - SPI_2MS
+#      - SPI_3MS
+#      - SPI_6MS
+#      - SPI_9MS
+#      - SPI_12MS
+#      - SPI_24MS
 RegistryEntryAdded: "2022-11-30"
-RegistryEntryLastModified: "2022-12-05"  
+RegistryEntryLastModified: "2022-12-19"  


### PR DESCRIPTION
OpenEO does not support zarr collectiosn currently, 

remove stac metadata until a sytem is developed to separate edc browser collections and openeo collections is developed