### PR TITLE
Fix broken license link for the Copernicus DEM

### DIFF
--- a/collections/copernicus-dem.yaml
+++ b/collections/copernicus-dem.yaml
@@ -32,10 +32,9 @@ Tags:
   - raster
   - open data
   - systematic
-
-License: "[License](https://spacedata.copernicus.eu/documents/20126/0/CSCDA_ESA_Mission-specific+Annex+%281%29.pdf/83b44c0a-244a-7ba3-b00c-b578a34e88a7?t=1604070311399) (Pages 15-20)"
+License: "[License](https://spacedata.copernicus.eu/en/web/guest/collections/copernicus-digital-elevation-model/#Licencing)"
 LicenseType: proprietary 
-LicenseUrl: https://spacedata.copernicus.eu/documents/20126/0/CSCDA_ESA_Mission-specific+Annex+%281%29.pdf/83b44c0a-244a-7ba3-b00c-b578a34e88a7?t=1604070311399
+LicenseUrl: https://spacedata.copernicus.eu/en/web/guest/collections/copernicus-digital-elevation-model/#Licencing
 Resources:
   - Group: Sentinel Hub Resources
     EndPoint: https://services.sentinel-hub.com
@@ -151,4 +150,4 @@ Summaries:
         maximum:
           - 1
 RegistryEntryAdded: "2020-11-30"
-RegistryEntryLastModified: "2022-11-23"
+RegistryEntryLastModified: "2023-01-03"


### PR DESCRIPTION
Closes #273 

This PR:

- Updates `License:` and `LicenseUrl:` with the correct links
- Removes extra spaces