### PR TITLE
Vegetation Indices: Update temporal availability to ongoing

### DIFF
--- a/collections/vegetation-indices.yaml
+++ b/collections/vegetation-indices.yaml
@@ -15,7 +15,7 @@ EOBrowser: https://apps.sentinel-hub.com/eo-browser/?zoom=10&lat=41.9&lng=12.5&t
 Image: vegetation-indices/thumbnail.png
 Resolution: 10m
 GeographicalCoverage: Europe (Lat; 26N 72N Lon; -25W 45E)
-TemporalAvailability: 2016-10-01 - 2022-11-09
+TemporalAvailability: 2016-10-01 - Ongoing
 UpdateFrequency: Daily
 BandInformation:
   Table:
@@ -143,7 +143,7 @@ Extent:
     interval:
       -
         - '2016-10-01T09:20:22Z'
-        - '2022-11-09T14:10:52Z'
+        - null
 CubeDimensions:
   x:
     type: spatial
@@ -225,7 +225,7 @@ CubeDimensions:
     type: temporal
     extent:
       - '2016-10-01T09:20:22Z'
-      - '2022-11-09T14:10:52Z'
+      - null
     step: P5D
   bands:
     type: bands
@@ -418,4 +418,4 @@ CRS:
   - "http://www.opengis.net/def/crs/EPSG/0/32760"
   - "http://www.opengis.net/def/crs/SR-ORG/0/98739"
 RegistryEntryAdded: '2021-10-14'
-RegistryEntryLastModified: "2022-11-11"
+RegistryEntryLastModified: "2023-02-13"

--- a/collections/vegetation-indices.yaml
+++ b/collections/vegetation-indices.yaml
@@ -15,7 +15,7 @@ EOBrowser: https://apps.sentinel-hub.com/eo-browser/?zoom=10&lat=41.9&lng=12.5&t
 Image: vegetation-indices/thumbnail.png
 Resolution: 10m
 GeographicalCoverage: Europe (Lat; 26N 72N Lon; -25W 45E)
-TemporalAvailability: 2016-10-01 - Ongoing
+TemporalAvailability: 2016-10-01 - ongoing
 UpdateFrequency: Daily
 BandInformation:
   Table:


### PR DESCRIPTION
a lamda function has been set up to ingest HRVPP newly available data as soon as they are available

I suggest to set the temporal availability to `ongoing`  and temporal extent end date to `null` 


@dthiex  please review