### PR TITLE
Directly link Sentinel license

### DIFF
--- a/_build/stac.hbs
+++ b/_build/stac.hbs
@@ -49,9 +49,9 @@
       "wmts:dimensions": {{{copyJson (find WMTS 'dimensions' 'dimensions')}}}
     },
     {{/if}}
-{{#each Configurations}}
-	{{{copyJson this}}},
-{{/each}}
+    {{#each Configurations}}
+	    {{{copyJson this}}},
+    {{/each}}
     {{#if DocumentationLinks }}    
     {
       "href": "{{{find DocumentationLinks 'href' 'href'}}}",
@@ -63,7 +63,7 @@
     {
       "href": "{{{escapeJson LicenseUrl}}}",
       "rel": "license",
-      "type": "text/html",
+      "type": {{#if LicenseUrlType }} "{{{LicenseUrlType}}}" {{else}} "text/html" {{/if ~}},
       "title": "License"
     }
   ],

--- a/collections/sentinel-1-grd.yaml
+++ b/collections/sentinel-1-grd.yaml
@@ -38,9 +38,9 @@ Tags:
   - open data
   - race challenges
   - sentinel
-License: "[License](https://docs.sentinel-hub.com/api/latest/data/sentinel-1-grd/#attribution-and-use)"
+License: "[License](https://sentinels.copernicus.eu/documents/247904/690755/Sentinel_Data_Legal_Notice)"
 LicenseType: proprietary 
-LicenseUrl: https://docs.sentinel-hub.com/api/latest/data/sentinel-1-grd/#attribution-and-use
+LicenseUrl: https://sentinels.copernicus.eu/documents/247904/690755/Sentinel_Data_Legal_Notice
 Resources:
   - Group: Sentinel Hub Resources
   - EndPoint: https://services.sentinel-hub.com

--- a/collections/sentinel-1-grd.yaml
+++ b/collections/sentinel-1-grd.yaml
@@ -41,6 +41,7 @@ Tags:
 License: "[License](https://sentinels.copernicus.eu/documents/247904/690755/Sentinel_Data_Legal_Notice)"
 LicenseType: proprietary 
 LicenseUrl: https://sentinels.copernicus.eu/documents/247904/690755/Sentinel_Data_Legal_Notice
+LicenseUrlType: application/pdf
 Resources:
   - Group: Sentinel Hub Resources
   - EndPoint: https://services.sentinel-hub.com

--- a/collections/sentinel-2-l1c.yaml
+++ b/collections/sentinel-2-l1c.yaml
@@ -36,6 +36,7 @@ Tags:
 License: "[License](https://sentinels.copernicus.eu/documents/247904/690755/Sentinel_Data_Legal_Notice)"
 LicenseType: proprietary 
 LicenseUrl: https://sentinels.copernicus.eu/documents/247904/690755/Sentinel_Data_Legal_Notice
+LicenseUrlType: application/pdf
 Resources:
   - Group: Sentinel Hub Resources
   - EndPoint: https://services.sentinel-hub.com

--- a/collections/sentinel-2-l1c.yaml
+++ b/collections/sentinel-2-l1c.yaml
@@ -33,9 +33,9 @@ Tags:
   - race challenges
   - copernicus
   - sentinel
-License: "[License](https://docs.sentinel-hub.com/api/latest/data/sentinel-2-l1c/#attribution-and-use)"
+License: "[License](https://sentinels.copernicus.eu/documents/247904/690755/Sentinel_Data_Legal_Notice)"
 LicenseType: proprietary 
-LicenseUrl: https://docs.sentinel-hub.com/api/latest/data/sentinel-2-l1c/#attribution-and-use
+LicenseUrl: https://sentinels.copernicus.eu/documents/247904/690755/Sentinel_Data_Legal_Notice
 Resources:
   - Group: Sentinel Hub Resources
   - EndPoint: https://services.sentinel-hub.com

--- a/collections/sentinel-2-l2a.yaml
+++ b/collections/sentinel-2-l2a.yaml
@@ -37,6 +37,7 @@ License: |
     [License](https://sentinels.copernicus.eu/documents/247904/690755/Sentinel_Data_Legal_Notice)
 LicenseType: proprietary
 LicenseUrl: https://sentinels.copernicus.eu/documents/247904/690755/Sentinel_Data_Legal_Notice
+LicenseUrlType: application/pdf
 Resources:
   - Group: Sentinel Hub Resources
   - EndPoint: https://services.sentinel-hub.com

--- a/collections/sentinel-2-l2a.yaml
+++ b/collections/sentinel-2-l2a.yaml
@@ -34,9 +34,9 @@ Tags:
   - copernicus
   - sentinel
 License: |
-    [License](https://docs.sentinel-hub.com/api/latest/data/sentinel-2-l2a/#attribution-and-use)
+    [License](https://sentinels.copernicus.eu/documents/247904/690755/Sentinel_Data_Legal_Notice)
 LicenseType: proprietary
-LicenseUrl: https://docs.sentinel-hub.com/api/latest/data/sentinel-2-l2a/#attribution-and-use
+LicenseUrl: https://sentinels.copernicus.eu/documents/247904/690755/Sentinel_Data_Legal_Notice
 Resources:
   - Group: Sentinel Hub Resources
   - EndPoint: https://services.sentinel-hub.com

--- a/collections/sentinel-3-l1b-olci.yaml
+++ b/collections/sentinel-3-l1b-olci.yaml
@@ -40,6 +40,7 @@ Tags:
 License: "[License](https://sentinels.copernicus.eu/documents/247904/690755/Sentinel_Data_Legal_Notice)"
 LicenseType: proprietary 
 LicenseUrl: https://sentinels.copernicus.eu/documents/247904/690755/Sentinel_Data_Legal_Notice
+LicenseUrlType: application/pdf
 Resources:
   - Group: Sentinel Hub Resources
   - EndPoint: https://creodias.sentinel-hub.com

--- a/collections/sentinel-3-l1b-olci.yaml
+++ b/collections/sentinel-3-l1b-olci.yaml
@@ -37,9 +37,9 @@ Tags:
   - race challenges
   - copernicus
   - sentinel
-License: "[License](https://docs.sentinel-hub.com/api/latest/data/sentinel-3-olci-l1b/#attribution-and-use)"
+License: "[License](https://sentinels.copernicus.eu/documents/247904/690755/Sentinel_Data_Legal_Notice)"
 LicenseType: proprietary 
-LicenseUrl: https://docs.sentinel-hub.com/api/latest/data/sentinel-1-grd/#attribution-and-use
+LicenseUrl: https://sentinels.copernicus.eu/documents/247904/690755/Sentinel_Data_Legal_Notice
 Resources:
   - Group: Sentinel Hub Resources
   - EndPoint: https://creodias.sentinel-hub.com

--- a/collections/sentinel-3-l1b-slstr.yaml
+++ b/collections/sentinel-3-l1b-slstr.yaml
@@ -40,6 +40,7 @@ Tags:
 License: "[License](https://sentinels.copernicus.eu/documents/247904/690755/Sentinel_Data_Legal_Notice)"
 LicenseType: proprietary
 LicenseUrl: https://sentinels.copernicus.eu/documents/247904/690755/Sentinel_Data_Legal_Notice
+LicenseUrlType: application/pdf
 Resources:
   - Group: Sentinel Hub Resources
   - EndPoint: https://creodias.sentinel-hub.com

--- a/collections/sentinel-3-l1b-slstr.yaml
+++ b/collections/sentinel-3-l1b-slstr.yaml
@@ -37,9 +37,9 @@ Tags:
   - race challenges
   - copernicus
   - sentinel
-License: "[License](https://docs.sentinel-hub.com/api/latest/data/sentinel-3-slstr-l1b/#attribution-and-use)"
+License: "[License](https://sentinels.copernicus.eu/documents/247904/690755/Sentinel_Data_Legal_Notice)"
 LicenseType: proprietary
-LicenseUrl: https://docs.sentinel-hub.com/api/latest/data/sentinel-3-slstr-l1b/#attribution-and-use
+LicenseUrl: https://sentinels.copernicus.eu/documents/247904/690755/Sentinel_Data_Legal_Notice
 Resources:
   - Group: Sentinel Hub Resources
   - EndPoint: https://creodias.sentinel-hub.com

--- a/collections/sentinel-5p-l2-tropomi.yaml
+++ b/collections/sentinel-5p-l2-tropomi.yaml
@@ -35,9 +35,9 @@ Tags:
   - race challenges
   - copernicus
   - sentinel
-License: "[License](https://docs.sentinel-hub.com/api/latest/data/sentinel-5p-l2/#attribution-and-use)"
+License: "[License](https://sentinels.copernicus.eu/documents/247904/690755/Sentinel_Data_Legal_Notice)"
 LicenseType: proprietary
-LicenseUrl: https://docs.sentinel-hub.com/api/latest/data/sentinel-5p-l2/#attribution-and-use
+LicenseUrl: https://sentinels.copernicus.eu/documents/247904/690755/Sentinel_Data_Legal_Notice
 Resources:
   - Group: Sentinel Hub Resources
   - EndPoint: https://creodias.sentinel-hub.com

--- a/collections/sentinel-5p-l2-tropomi.yaml
+++ b/collections/sentinel-5p-l2-tropomi.yaml
@@ -38,6 +38,7 @@ Tags:
 License: "[License](https://sentinels.copernicus.eu/documents/247904/690755/Sentinel_Data_Legal_Notice)"
 LicenseType: proprietary
 LicenseUrl: https://sentinels.copernicus.eu/documents/247904/690755/Sentinel_Data_Legal_Notice
+LicenseUrlType: application/pdf
 Resources:
   - Group: Sentinel Hub Resources
   - EndPoint: https://creodias.sentinel-hub.com


### PR DESCRIPTION
Closes #290 

This PR:
- Links Sentinel license directly to https://sentinels.copernicus.eu/documents/247904/690755/Sentinel_Data_Legal_Notice for S1-GRD, S2-L1C /L2A, S3-OLCI/SLSTR and S5P