### PR TITLE
remove space causing problems in generated json

### DIFF
--- a/_build/stac.hbs
+++ b/_build/stac.hbs
@@ -63,7 +63,7 @@
     {
       "href": "{{{escapeJson LicenseUrl}}}",
       "rel": "license",
-      "type": {{#if LicenseUrlType }} "{{{LicenseUrlType}}}"{{else}} "text/html" {{/if ~}},
+      "type": {{#if LicenseUrlType }} "{{{LicenseUrlType}}}"{{else}} "text/html"{{/if ~}},
       "title": "License"
     }
   ],

--- a/_build/stac.hbs
+++ b/_build/stac.hbs
@@ -63,7 +63,7 @@
     {
       "href": "{{{escapeJson LicenseUrl}}}",
       "rel": "license",
-      "type": {{#if LicenseUrlType }} "{{{LicenseUrlType}}}" {{else}} "text/html" {{/if ~}},
+      "type": {{#if LicenseUrlType }} "{{{LicenseUrlType}}}"{{else}} "text/html" {{/if ~}},
       "title": "License"
     }
   ],


### PR DESCRIPTION
Fixes an issue where there was an empty space too much in the generated json

    {
      "href": "https://sentinels.copernicus.eu/documents/247904/690755/Sentinel_Data_Legal_Notice",
      "rel": "license",
      "type":  "application/pdf" , // <- HERE
      "title": "License"
    }