### PR TITLE
move about link object and add licensetype filter

### DIFF
--- a/_build/stac.hbs
+++ b/_build/stac.hbs
@@ -39,12 +39,6 @@
       "href": "https://collections.eurodatacube.com/stac/{{Slug}}.json",
       "rel": "self"
     },
-    {
-      "href": "./{{Slug}}",
-      "rel": "about",
-      "type": "text/html",
-      "title": "Website describing the collection"
-    },
     {{#if WMTS }}    
     {
       "href": "{{{find WMTS 'href' 'href'}}}",
@@ -64,11 +58,19 @@
       "title": "{{{find DocumentationLinks 'title' 'title'}}}"  
     },
     {{/if}}
+    {{#if LicenseType }}
     {
       "href": "{{{escapeJson LicenseUrl}}}",
       "rel": "license",
       "type": {{#if LicenseUrlType }} "{{{LicenseUrlType}}}"{{else}} "text/html"{{/if ~}},
       "title": "License"
+    },
+    {{/if}}
+    {
+      "href": "./{{Slug}}",
+      "rel": "about",
+      "type": "text/html",
+      "title": "Website describing the collection"
     }
   ],
   "cube:dimensions": {{{copyJson CubeDimensions}}},

--- a/_build/stac.hbs
+++ b/_build/stac.hbs
@@ -58,7 +58,7 @@
       "title": "{{{find DocumentationLinks 'title' 'title'}}}"  
     },
     {{/if}}
-    {{#if LicenseType }}
+    {{#if LicenseUrl }}
     {
       "href": "{{{escapeJson LicenseUrl}}}",
       "rel": "license",


### PR DESCRIPTION
Only add license link object if LicenseUrl is defined. Because of that I had to move the about link object to the end as otherwise there is some issue with the comma being added too much in case LicenseUrl is defined. 

I tried to fix this in the past better but we couldn't find a quick solution.