### PR TITLE
add experimental flag to creodias collections

### DIFF
--- a/collections/card4l.yaml
+++ b/collections/card4l.yaml
@@ -166,5 +166,6 @@ Summaries:
         unit: °
     - description: The mask of data/no data pixels.
       name: dataMask
+Experimental: true
 RegistryEntryAdded: "2022-02-11"
 RegistryEntryLastModified: "2022-07-21"

--- a/collections/corine-land-cover-accounting-layers.yaml
+++ b/collections/corine-land-cover-accounting-layers.yaml
@@ -122,5 +122,6 @@ Summaries:
         unit: m
     - description: The mask of data/no data pixels.
       name: dataMask
+Experimental: true
 RegistryEntryAdded: "2021-10-20"
 RegistryEntryLastModified: "2022-07-04"

--- a/collections/corine-land-cover.yaml
+++ b/collections/corine-land-cover.yaml
@@ -115,5 +115,6 @@ Summaries:
         unit: m
     - description: The mask of data/no data pixels.
       name: dataMask
+Experimental: true
 RegistryEntryAdded: "2021-03-21"
 RegistryEntryLastModified: "2022-07-19"

--- a/collections/global-human-settlement-layer-ghs-built-s2.yaml
+++ b/collections/global-human-settlement-layer-ghs-built-s2.yaml
@@ -311,5 +311,6 @@ CRS:
   - "http://www.opengis.net/def/crs/EPSG/0/32760"
   - "http://www.opengis.net/def/crs/SR-ORG/0/98739"
 sci:citation: "Details on the use and access conditions [here](https://data.jrc.ec.europa.eu/dataset/016d1a34-b184-42dc-b586-e10b915dd863)."
+Experimental: true
 RegistryEntryAdded: "2022-01-10"
 RegistryEntryLastModified: "2024-08-13"

--- a/collections/global-land-cover.yaml
+++ b/collections/global-land-cover.yaml
@@ -269,5 +269,6 @@ Summaries:
         unit: °
     - description: The mask of data/no data pixels.
       name: dataMask
+Experimental: true
 RegistryEntryAdded: "2021-03-20"
 RegistryEntryLastModified: "2022-07-25"

--- a/collections/global-surface-water.yaml
+++ b/collections/global-surface-water.yaml
@@ -208,5 +208,6 @@ Summaries:
         unit: °
     - description: The mask of data/no data pixels.
       name: dataMask
+Experimental: true
 RegistryEntryAdded: "2021-04-19"
 RegistryEntryLastModified: "2024-08-13"

--- a/collections/hrsi-fsc.yaml
+++ b/collections/hrsi-fsc.yaml
@@ -168,5 +168,6 @@ CubeDimensions:
       - QCTOC
       - QCOG
       - NDSI
+Experimental: true
 RegistryEntryAdded: "2023-08-02"
 RegistryEntryLastModified: "2023-08-17"

--- a/collections/hrsi-gfsc.yaml
+++ b/collections/hrsi-gfsc.yaml
@@ -126,5 +126,6 @@ CubeDimensions:
     values:
       - GF
       - QC
+Experimental: true
 RegistryEntryAdded: "2023-08-02"
 RegistryEntryLastModified: "2023-08-17"

--- a/collections/hrsi-psa.yaml
+++ b/collections/hrsi-psa.yaml
@@ -130,5 +130,6 @@ CubeDimensions:
     values:
       - PSA
       - QC
+Experimental: true
 RegistryEntryAdded: "2023-08-02"
 RegistryEntryLastModified: "2023-08-17"

--- a/collections/hrsi-sws.yaml
+++ b/collections/hrsi-sws.yaml
@@ -126,5 +126,6 @@ CubeDimensions:
     values:
       - WSM
       - QCWSM
+Experimental: true
 RegistryEntryAdded: "2023-08-02"
 RegistryEntryLastModified: "2023-08-17"

--- a/collections/hrsi-wds.yaml
+++ b/collections/hrsi-wds.yaml
@@ -126,5 +126,6 @@ CubeDimensions:
     values:
       - SSC
       - QCSSC
+Experimental: true
 RegistryEntryAdded: "2023-08-02"
 RegistryEntryLastModified: "2023-08-17"

--- a/collections/seasonal-trajectories.yaml
+++ b/collections/seasonal-trajectories.yaml
@@ -353,5 +353,6 @@ CRS:
   - "http://www.opengis.net/def/crs/EPSG/0/32759"
   - "http://www.opengis.net/def/crs/EPSG/0/32760"
   - "http://www.opengis.net/def/crs/SR-ORG/0/98739"
+Experimental: true
 RegistryEntryAdded: '2021-10-14'
 RegistryEntryLastModified: "2022-11-09"

--- a/collections/sentinel-3-l1b-olci.yaml
+++ b/collections/sentinel-3-l1b-olci.yaml
@@ -743,5 +743,6 @@ CRS:
   - "http://www.opengis.net/def/crs/EPSG/0/32759"
   - "http://www.opengis.net/def/crs/EPSG/0/32760"
   - "http://www.opengis.net/def/crs/SR-ORG/0/98739"
+Experimental: true
 RegistryEntryAdded: "2018-04-17"
 RegistryEntryLastModified: "2022-11-23"

--- a/collections/sentinel-3-l1b-slstr.yaml
+++ b/collections/sentinel-3-l1b-slstr.yaml
@@ -464,5 +464,6 @@ CRS:
   - "http://www.opengis.net/def/crs/EPSG/0/32759"
   - "http://www.opengis.net/def/crs/EPSG/0/32760"
   - "http://www.opengis.net/def/crs/SR-ORG/0/98739"
+Experimental: true
 RegistryEntryAdded: "2018-04-17"
 RegistryEntryLastModified: "2022-11-23"

--- a/collections/sentinel-5p-l2-tropomi.yaml
+++ b/collections/sentinel-5p-l2-tropomi.yaml
@@ -532,5 +532,6 @@ CRS:
   - "http://www.opengis.net/def/crs/EPSG/0/32759"
   - "http://www.opengis.net/def/crs/EPSG/0/32760"
   - "http://www.opengis.net/def/crs/SR-ORG/0/98739"
+Experimental: true
 RegistryEntryAdded: "2018-04-17"
 RegistryEntryLastModified: "2024-08-13"

--- a/collections/vegetation-indices.yaml
+++ b/collections/vegetation-indices.yaml
@@ -417,5 +417,6 @@ CRS:
   - "http://www.opengis.net/def/crs/EPSG/0/32759"
   - "http://www.opengis.net/def/crs/EPSG/0/32760"
   - "http://www.opengis.net/def/crs/SR-ORG/0/98739"
+Experimental: true
 RegistryEntryAdded: '2021-10-14'
 RegistryEntryLastModified: "2023-02-13"

--- a/collections/vegetation-phenology-and-productivity-parameters-season-1.yaml
+++ b/collections/vegetation-phenology-and-productivity-parameters-season-1.yaml
@@ -583,5 +583,6 @@ CRS:
   - "http://www.opengis.net/def/crs/EPSG/0/32759"
   - "http://www.opengis.net/def/crs/EPSG/0/32760"
   - "http://www.opengis.net/def/crs/SR-ORG/0/98739"
+Experimental: true
 RegistryEntryAdded: '2021-10-14'
 RegistryEntryLastModified: "2022-11-09"

--- a/collections/vegetation-phenology-and-productivity-parameters-season-2.yaml
+++ b/collections/vegetation-phenology-and-productivity-parameters-season-2.yaml
@@ -583,5 +583,6 @@ CRS:
   - "http://www.opengis.net/def/crs/EPSG/0/32759"
   - "http://www.opengis.net/def/crs/EPSG/0/32760"
   - "http://www.opengis.net/def/crs/SR-ORG/0/98739"
+Experimental: true
 RegistryEntryAdded: '2021-10-14'
 RegistryEntryLastModified: "2022-11-09"

--- a/collections/water-bodies.yaml
+++ b/collections/water-bodies.yaml
@@ -143,5 +143,6 @@ Summaries:
         unit: °
     - description: The mask of data/no data pixels.
       name: dataMask
+Experimental: true
 RegistryEntryAdded: "2021-03-30"
 RegistryEntryLastModified: "2024-08-13"


### PR DESCRIPTION
This PR marks all collections on creodias as experimental as those will get removed once CF deprecates CF2 (our SH deployment there).