### PR TITLE
EDC Browser deprecation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,6 @@ AdditionalInfoExternal:
     Title:
     Path:
 Image:
-EDCBrowser:
 EOBrowser:
 Flickr:
 Explore:
@@ -189,7 +188,6 @@ Below is a description for each metadata field.
 |**AdditionalInfoExternal >> Title**|MD | Additional info. |
 |**AdditionalInfoExternal >> Path**|Path | Path to README.MD with additional info on the github repo.|
 |**Image**| Path | Path to thumbnail image representing the collection that is to be displayed on the homepage. Automatically sized to 200 pixels width for display. |
-| **EDC Browser** | String | Link to the collection displayed in the EDC Browser.|
 |**EOBrowser**|String | Link to the collection displayed in EO Browser. |
 |**Flickr**|String | Link to Flickr album if collection is not available on EO Browser. |
 |**Explore**|MD| Link to where the collection can be explored, e.g. Jupyter Notebook or graphical viewer. |

--- a/_build/detail.hbs
+++ b/_build/detail.hbs
@@ -27,19 +27,9 @@
       <p>{{{mdExternal AdditionalInfoExternal}}}</p>
       {{/if}}    
 
-      {{#if EDCBrowser}}
+      {{#if EOBrowser}}
       <h4>Explore</h4>
-      <p>
-            <a href="{{EDCBrowser}}" target="_blank"><button class="label label-info"> Open in EDC Browser </button></a>
-            {{#if EOBrowser}}
-            <a href="{{EOBrowser}}" target="_blank"><button class="label label-info" style="margin:10px"> Open in EO Browser </button></a>
-            {{/if}}
-      </p>
-      {{else}}
-            {{#if EOBrowser}}
-            <h4>Explore</h4>
-            <p><a href="{{EOBrowser}}" target="_blank"><button class="label label-info" > Open in EO Browser </button></a> </p>
-            {{/if}}
+      <p><a href="{{EOBrowser}}" target="_blank"><button class="label label-info" > Open in EO Browser </button></a> </p>
       {{/if}}
 
       {{#if TutorialNotebook}}

--- a/collections/2mt_2020_monthly_average_from_cds.yaml
+++ b/collections/2mt_2020_monthly_average_from_cds.yaml
@@ -5,7 +5,6 @@ AdditionalInfoExternal:
     Title: Additional info
     Path: 2mt_2020_monthly_average_from_cds/README.MD
 Image: 2mt_2020_monthly_average_from_cds/2mt_2020_monthly_average_from_cds.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=1&lat=0.00005&lng=0.00001&collectionId=2mt_2020_monthly_average_from_cds&layerId=2m%20Temperature%20Visualisation&type=sentinel-hub-edc&fromTime=2019-12-01T00%3A00%3A00.000Z&toTime=2020-12-01T00%3A00%3A00.000Z
 Resolution: 0.25° x 0.25°
 GeographicalCoverage: -179.999755859375, -90.12489004526765, 179.99977453631897, 90.125
 TemporalAvailability: 2019-01-01 - 2020-12-01

--- a/collections/alos-2-palsar-2-scansar-for-agriculture.yaml
+++ b/collections/alos-2-palsar-2-scansar-for-agriculture.yaml
@@ -11,7 +11,6 @@ Description: |
   vegetation to obtain information about vegetation and ground surface.
   ScanSAR is wide swath mode with 100m spatial resolution, 350km width swath, and dual polarization (HH/HV).
 Image: alos-2-palsar-2-scansar-for-agriculture/alos-2-palsar-2-scansar-for-agriculture.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=8&lat=40.5305&lng=-121.809&collectionId=alos-2-palsar-2-scansar-for-agriculture&layerId=HH&type=sentinel-hub-edc&fromTime=2019-12-31T00%3A00%3A00.000Z&toTime=2020-12-31T00%3A00%3A00.000Z
 AdditionalInfoExternal:
   Title: Additional info
   Path: alos-2-palsar-2-scansar-for-agriculture/README.MD

--- a/collections/alos-2-palsar-2-scansar-rice-fields-map.yaml
+++ b/collections/alos-2-palsar-2-scansar-rice-fields-map.yaml
@@ -5,7 +5,6 @@ Description: |
   geometrically corrected (orthorectified) data in selected AOIs between 2019 and 2020 for NASA/ESA/JAXA EODashboard Hackathon.
   The reference map is described in the digital code as 255: rice paddy field, 0: others.
 Image: alos-2-palsar-2-scansar-rice-fields-map/alos-2-palsar-2-scansar-rice-fields-map.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=12&lat=39.57112&lng=-121.97664&collectionId=alos-2-palsar-2-scansar-rice-fields-map&layerId=Reference%20Rice%20Paddy%20Map&type=sentinel-hub-edc&fromTime=2019-08-31T00%3A00%3A00.000Z&toTime=2020-08-31T00%3A00%3A00.000Z
 AdditionalInfoExternal:
   Title: Additional info
   Path: alos-2-palsar-2-scansar-rice-fields-map/README.MD

--- a/collections/alos-2-palsar-2-stripmap-for-economy-sm1.yaml
+++ b/collections/alos-2-palsar-2-stripmap-for-economy-sm1.yaml
@@ -11,7 +11,6 @@ Description: |
   vegetation to obtain information about vegetation and ground surface.
   Data for Tokyo and Los Angeles are Strip Map mode 1 (SM1) which is fine mode with 3m spatial resolution with 50km width swath and single polarization (HH).
 Image: alos-2-palsar-2-stripmap-for-economy-sm1/alos-2-palsar-2-stripmap-for-economy-sm1.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=10&lat=35.616&lng=139.774&collectionId=alos-2-palsar-2-stripmap-for-economy-sm1&layerId=HH&type=sentinel-hub-edc&fromTime=2020-04-18T00%3A00%3A00.000Z&toTime=2021-04-18T00%3A00%3A00.000Z
 Resolution: |
  SM1: 3m
 GeographicalCoverage: |

--- a/collections/alos-2-palsar-2-stripmap-for-economy.yaml
+++ b/collections/alos-2-palsar-2-stripmap-for-economy.yaml
@@ -12,7 +12,6 @@ Description: |
   Data for Paris and Dunkirk are Strip Map mode 3 (SM3) which is fine mode with 10m spatial resolution with 70km width swath and dual polarization (HH/HV),
   while Beijing data is both Strip Map mode 3 (SM3) and Strip Map mode 1 (SM1) which is also fine mode with 3m spatial resolution with 50km width swath and dual polarization (HH/HV).
 Image: alos-2-palsar-2-stripmap-for-economy/alos-2-palsar-2-stripmap-for-economy.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=10&lat=48.90326&lng=2.43442&collectionId=alos-2-palsar-2-stripmap-for-economy&layerId=HH&type=sentinel-hub-edc&fromTime=2019-12-31T00%3A00%3A00.000Z&toTime=2021-12-31T00%3A00%3A00.000Z
 AdditionalInfoExternal:
   Title: Additional info
   Path: alos-2-palsar-2-stripmap-for-economy/README.MD

--- a/collections/cams_glc_2017.yaml
+++ b/collections/cams_glc_2017.yaml
@@ -5,7 +5,6 @@ AdditionalInfoExternal:
     Title: Additional info
     Path: cams_glc_2017/README.MD
 Image: cams_glc_2017/cams_glc_2017.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=10&lat=41.9&lng=12.5&collectionId=cams_glc_2017&layerId=Land%20Cover%20Classification&type=sentinel-hub-edc&fromTime=2016-12-31T00%3A00%3A00.000Z&toTime=2017-12-31T00%3A00%3A00.000Z
 Resolution: 10m
 GeographicalCoverage: -33.56847525983416, 31.857766985498905, 62.19564440228477, 72.37088743023797
 TemporalAvailability: "2017"

--- a/collections/chl_water_quality_saturday.yaml
+++ b/collections/chl_water_quality_saturday.yaml
@@ -5,7 +5,6 @@ AdditionalInfoExternal:
     Title: Additional info
     Path: chl_water_quality_saturday/README.MD
 Image: chl_water_quality_saturday/chl_water_quality_saturday.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=7&lat=43.14975&lng=7.16013&collectionId=chl_water_quality_saturday&layerId=Chlorophyll%20Anomaly%20Map&type=sentinel-hub-edc&fromTime=2020-04-17T00%3A00%3A00.000Z&toTime=2021-04-17T00%3A00%3A00.000Z
 Resolution: 300m
 GeographicalCoverage: 0.4982046708598385, 40.498973093940286, 13.82206392288208, 45.80052375793457
 TemporalAvailability: 2020-01-04 - ongoing

--- a/collections/cnes-land-cover-map.yaml
+++ b/collections/cnes-land-cover-map.yaml
@@ -7,7 +7,6 @@ AdditionalInfoExternal:
     Title: Additional info
     Path: cnes-land-cover-map/README.MD
 Image: cnes-land-cover-map/cnes-land-cover-map-france-overview.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=6&lat=46.77491&lng=-0.08909&collectionId=cnes-land-cover-map&layerId=CNES%20Land%20Cover%20Map&type=sentinel-hub-edc&fromTime=2019-12-31T00%3A00%3A00.000Z&toTime=2020-12-31T00%3A00%3A00.000Z
 EOBrowser: https://apps.sentinel-hub.com/eo-browser/?zoom=6&lat=46.56146&lng=1.72073&themeId=DEFAULT-THEME&visualizationUrl=https%3A%2F%2Fservices.sentinel-hub.com%2Fogc%2Fwms%2Fcbb61b40-873e-4c33-a15c-0aaf6dd9c773&datasetId=CNES_LAND_COVER&fromTime=2020-01-01T00%3A00%3A00.000Z&toTime=2020-01-01T23%3A59%3A59.999Z&layerId=CNES-LAND-COVER-CLASSIFICATION
 Resolution: 10m
 GeographicalCoverage: Metropolitan France with longitude from 6.26°W to 11.85°E and latitude from 51.45°N to 40.46°N

--- a/collections/co_3daily_data.yaml
+++ b/collections/co_3daily_data.yaml
@@ -9,7 +9,6 @@ AdditionalInfoExternal:
   Title: Additional info
   Path: co_3daily_data/README.MD
 Image: co_3daily_data/co.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=3&lat=3.25021&lng=30.9375&collectionId=SENTINEL_5P_CO_T3D_AVERAGE&layerId=co-3daily&type=sentinel-hub-edc&fromTime=2023-02-08T23%3A00%3A00.000Z&toTime=2023-02-09T22%3A59%3A59.999Z
 Resolution: 4.8 x 4.8 Km (across x along track)
 GeographicalCoverage: -180.0, -90.0, 180.0, 90.0
 TemporalAvailability: 2018-04-30 - ongoing

--- a/collections/copernicus-dem.yaml
+++ b/collections/copernicus-dem.yaml
@@ -11,7 +11,6 @@ Description: |
   and "COP-DEM GLO-90" in areas where "COP-DEM GLO-30 Public" tiles are not yet released to the public by Copernicus Programme.
   Copernicus DEM provides elevation data and can also be used for the orthorectification of satellite imagery (e.g Sentinel 1).
 Documentation: "[here](https://docs.sentinel-hub.com/api/latest/data/dem/)"
-EDCBrowser: https://browser.eurodatacube.com/?zoom=7&lat=43.14975&lng=7.16013&collectionId=copernicus-dem&layerId=Color&type=sentinel-hub-edc&fromTime=2014-01-16T01%3A37%3A12.000Z&toTime=2015-01-16T01%3A37%3A12.000Z
 EOBrowser: https://apps.sentinel-hub.com/eo-browser/?zoom=10&lat=41.9&lng=12.5&themeId=DEFAULT-THEME&visualizationUrl=https%3A%2F%2Fservices.sentinel-hub.com%2Fogc%2Fwms%2F6448ffd0-56c5-4601-bed7-242bf75d97db&datasetId=DEM_COPERNICUS_30&fromTime=2021-04-08T00%3A00%3A00.000Z&toTime=2021-04-08T23%3A59%3A59.999Z&layerId=COLOR
 Image: copernicus-dem/copernicus-dem.png
 Resolution: 30m and 90m

--- a/collections/e12c_motorway.yaml
+++ b/collections/e12c_motorway.yaml
@@ -5,7 +5,6 @@ AdditionalInfoExternal:
     Title: Additional info
     Path: e12c_motorway/README.MD
 Image: e12c_motorway/e12c_motorway.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=5&lat=49.88048&lng=3.25195&collectionId=e12c_motorway&layerId=Trucks%20E12C%20Motorway&type=sentinel-hub-edc&fromTime=2019-05-15T23%3A59%3A59.000Z&toTime=2020-05-15T23%3A59%3A59.000Z
 Resolution: 0.089932160591873,-0.089932160591873
 GeographicalCoverage: -31.26818657, 27.693670044054727, 34.06794939183746, 70.09145355
 TemporalAvailability: 2017-05-15 - 2020-05-15

--- a/collections/e12d_primary_corrected.yaml
+++ b/collections/e12d_primary_corrected.yaml
@@ -5,7 +5,6 @@ AdditionalInfoExternal:
     Title: Additional info
     Path: e12d_primary_corrected/README.MD
 Image: e12d_primary_corrected/e12d_primary_corrected.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=4&lat=48.89256&lng=1.39988&collectionId=e12d_primary_corrected&layerId=Trucks%20E12D%20Motorway&type=sentinel-hub-edc&fromTime=2019-05-15T23%3A59%3A59.000Z&toTime=2020-05-15T23%3A59%3A59.000Z
 Resolution: 0.089932160591873,-0.089932160591873
 GeographicalCoverage: -31.26818657, 27.693670044054727, 34.06794939183746, 70.09145355
 TemporalAvailability: 2017-05-15 - 2020-05-15

--- a/collections/ecosystem.yaml
+++ b/collections/ecosystem.yaml
@@ -7,7 +7,6 @@ AdditionalInfoExternal:
   Title: Additional info
   Path: ecosystem/README.MD
 Image: ecosystem/thumbnail.png
-EDCBrowser: ""
 Resolution: 20m
 GeographicalCoverage: "Hungary (16.0°, 45.0°, 23.0°, 49.0°)"
 TemporalAvailability: "2015"

--- a/collections/harmonized-landsat-sentinel.yaml
+++ b/collections/harmonized-landsat-sentinel.yaml
@@ -8,7 +8,6 @@ Description: |
   April 2013 and Sentinel-2 data from November 2015.
 Documentation: "[here](https://docs.sentinel-hub.com/api/latest/data/hls/)"
 Image: harmonized-landsat-sentinel/harmonized-landsat-sentinel.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=11&lat=46.69584&lng=9.8307&collectionId=NASA_HARMONIZED_LANDSAT_SENTINEL&layerId=True%20Color&type=sentinel-hub-edc&fromTime=2023-06-24T22%3A00%3A00.000Z&toTime=2023-06-25T21%3A59%3A59.999Z
 EOBrowser: https://apps.sentinel-hub.com/eo-browser/?zoom=12&lat=45.66169&lng=12.77023&themeId=DEFAULT-THEME&visualizationUrl=https%3A%2F%2Fservices.sentinel-hub.com%2Fogc%2Fwms%2Fa10a1628-76ea-4654-8961-6494cb74576d&datasetId=AWS_HLS&fromTime=2022-10-27T00%3A00%3A00.000Z&toTime=2022-10-27T23%3A59%3A59.999Z&layerId=TRUE-COLOR&demSource3D=%22MAPZEN%22
 Resolution: 30m
 GeographicalCoverage: Globally

--- a/collections/hrsi-fsc.yaml
+++ b/collections/hrsi-fsc.yaml
@@ -13,7 +13,6 @@ AdditionalInfoExternal:
     Title: Additional info
     Path: hrsi-fsc/README.MD
 Image: hrsi-fsc/hrsi-fsc.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=11&lat=46.56429&lng=8.2782&collectionId=FRACTIONAL_SNOW_COVER&layerId=Fractional%20Snow%20Cover%20On-ground&type=sentinel-hub-edc&fromTime=2023-04-09T00%3A00%3A00.000Z&toTime=2023-04-09T23%3A59%3A59.999Z
 EOBrowser: https://sentinelshare.page.link/aUUT
 Resolution: 20m
 GeographicalCoverage: Europe (Lat; 34N 66N Lon; -26W 44E)

--- a/collections/hrsi-psa.yaml
+++ b/collections/hrsi-psa.yaml
@@ -17,7 +17,6 @@ AdditionalInfoExternal:
     Title: Additional info
     Path: hrsi-psa/README.MD
 Image: hrsi-psa/hrsi-psa.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=11&lat=46.54304&lng=7.95273&collectionId=PERSISTENT_SNOW_AREA&layerId=Persistent%20Snow%20Area&type=sentinel-hub-edc&fromTime=2021-05-09T00%3A00%3A00.000Z&toTime=2021-05-09T23%3A59%3A59.999Z
 EOBrowser: https://sentinelshare.page.link/tWUV
 Resolution: 20m
 GeographicalCoverage: Europe (Lat; 34N 66N Lon; -26W 44E)

--- a/collections/hrsi-rlie-s1.yaml
+++ b/collections/hrsi-rlie-s1.yaml
@@ -8,7 +8,6 @@ Description: |
 AdditionalInfoExternal:
   Title: Additional info
   Path: hrsi-rlie-s1/README.MD
-EDCBrowser: https://browser.eurodatacube.com/?zoom=10&lat=67.87166&lng=15.89722&collectionId=EEA_RIVER_AND_LAKE_ICE_EXTENT_SENTINEL1&layerId=RLIE&type=sentinel-hub-edc&fromTime=2023-05-01T00%3A00%3A00.000Z&toTime=2023-05-01T23%3A59%3A59.999Z
 EOBrowser: https://sentinelshare.page.link/SRi1
 Image: hrsi-rlie-s1/thumbnail.png
 Resolution: 20m

--- a/collections/hrsi-rlie-s1s2.yaml
+++ b/collections/hrsi-rlie-s1s2.yaml
@@ -8,7 +8,6 @@ Description: |
 AdditionalInfoExternal:
   Title: Additional info
   Path: hrsi-rlie-s1s2/README.MD
-EDCBrowser: https://browser.eurodatacube.com/?zoom=8&lat=66.68017&lng=17.80884&collectionId=RIVER_AND_LAKE_ICE_EXTENT_SENTINEL1_SENTINEL2&layerId=RLIE&type=sentinel-hub-edc&fromTime=2023-02-03T00%3A00%3A00.000Z&toTime=2023-02-03T23%3A59%3A59.999Z
 EOBrowser: https://sentinelshare.page.link/LszN
 Image: hrsi-rlie-s1s2/thumbnail.png
 Resolution: 20m

--- a/collections/hrsi-rlie-s2.yaml
+++ b/collections/hrsi-rlie-s2.yaml
@@ -8,7 +8,6 @@ Description: |
 AdditionalInfoExternal:
   Title: Additional info
   Path: hrsi-rlie-s2/README.MD
-EDCBrowser: https://browser.eurodatacube.com/?zoom=8&lat=65.79264&lng=17.02332&collectionId=RIVER_AND_LAKE_ICE_EXTENT_SENTINEL2&layerId=RLIE&type=sentinel-hub-edc&fromTime=2023-02-02T23%3A00%3A00.000Z&toTime=2023-02-03T22%3A59%3A59.999Z
 EOBrowser: https://sentinelshare.page.link/1ZyX
 Image: hrsi-rlie-s2/thumbnail.png
 Resolution: 20m

--- a/collections/hrsi-sws.yaml
+++ b/collections/hrsi-sws.yaml
@@ -13,7 +13,6 @@ AdditionalInfoExternal:
     Title: Additional info
     Path: hrsi-sws/README.MD
 Image: hrsi-sws/hrsi-sws.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=11&lat=46.5709&lng=9.71878&collectionId=SAR_WET_SNOW_IN_HIGH_MOUNTAINS&layerId=SAR%20Wet%20Snow&type=sentinel-hub-edc&fromTime=2023-05-04T00%3A00%3A00.000Z&toTime=2023-05-04T23%3A59%3A59.999Z
 EOBrowser: https://sentinelshare.page.link/c5WM
 Resolution: 60m
 GeographicalCoverage: Europe (Lat; 34N 66N Lon; -26W 44E)

--- a/collections/hrsi-wds.yaml
+++ b/collections/hrsi-wds.yaml
@@ -13,7 +13,6 @@ AdditionalInfoExternal:
     Title: Additional info
     Path: hrsi-wds/README.MD
 Image: hrsi-wds/hrsi-wds.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=11&lat=46.58317&lng=9.48601&collectionId=WET_DRY_SNOW_STATE_CLASSIFICATION&layerId=Snow%20State%20Classification&type=sentinel-hub-edc&fromTime=2023-04-26T00%3A00%3A00.000Z&toTime=2023-04-26T23%3A59%3A59.999Z
 EOBrowser: https://sentinelshare.page.link/YUdR
 Resolution: 60m
 GeographicalCoverage: Europe (Lat; 34N 66N Lon; -26W 44E)

--- a/collections/iceye_e11.yaml
+++ b/collections/iceye_e11.yaml
@@ -5,7 +5,6 @@ AdditionalInfoExternal:
     Title: Additional info
     Path: iceye_e11/README.MD
 Image: iceye_e11/iceye_e11.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=15&lat=48.87151&lng=2.78395&collectionId=iceye_e11&layerId=GRD%20ICEYE_E11&type=sentinel-hub-edc&fromTime=2019-03-20T23%3A59%3A59.000Z&toTime=2020-03-20T23%3A59%3A59.000Z
 Resolution: Pixel Size = (0.0000060,-0.0000060)
 GeographicalCoverage: 2.769154472, 48.861336953, 2.7987541, 48.881687237
 TemporalAvailability: 2020-03-20 - 2020-03-20

--- a/collections/iceye_e11a.yaml
+++ b/collections/iceye_e11a.yaml
@@ -5,7 +5,6 @@ AdditionalInfoExternal:
     Title: Additional info
     Path: iceye_e11a/README.MD
 Image: iceye_e11a/iceye_e11a.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=15&lat=52.24237&lng=21.04568&collectionId=iceye_e11a&layerId=GRD%20ICEYE_E11a&type=sentinel-hub-edc&fromTime=2019-04-13T23%3A59%3A59.000Z&toTime=2020-04-13T23%3A59%3A59.000Z
 Resolution: Pixel Size = (0.0000060,-0.0000060)
 GeographicalCoverage: 21.039070567, 52.235855988, 21.052287012, 52.248886356
 TemporalAvailability: 2020-02-07 - 2020-04-13

--- a/collections/iceye_e13b.yaml
+++ b/collections/iceye_e13b.yaml
@@ -5,7 +5,6 @@ AdditionalInfoExternal:
     Title: Additional info
     Path: iceye_e13b/README.MD
 Image: iceye_e13b/iceye_e13b.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=14&lat=40.41555&lng=-1.23107&collectionId=iceye_e13b&layerId=GRD%20ICEYE_E13b&type=sentinel-hub-edc&fromTime=2019-08-25T23%3A59%3A59.000Z&toTime=2020-08-25T23%3A59%3A59.000Z
 Resolution: Pixel Size = (0.0000060,-0.0000060)
 GeographicalCoverage: -1.245691996, 40.394458816, 8.533407797, 50.049107756
 TemporalAvailability: 2020-02-04 - 2020-08-29

--- a/collections/iceye_e3.yaml
+++ b/collections/iceye_e3.yaml
@@ -5,7 +5,6 @@ AdditionalInfoExternal:
     Title: Additional info
     Path: iceye_e3/README.MD
 Image: iceye_e3/iceye_e3.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=16&lat=51.95218&lng=4.09373&collectionId=iceye_e3&layerId=GRD%20ICEYE_E3&type=sentinel-hub-edc&fromTime=2019-07-17T23%3A59%3A59.000Z&toTime=2020-07-17T23%3A59%3A59.000Z
 Resolution: Pixel Size = (0.0000060,-0.0000060)
 GeographicalCoverage: 4.08589, 51.94683, 4.10156, 51.95753
 TemporalAvailability: 2020-02-04 - 2020-07-17

--- a/collections/idiv-central-asia.yaml
+++ b/collections/idiv-central-asia.yaml
@@ -5,7 +5,6 @@ AdditionalInfoExternal:
   Title: Additional info
   Path: idiv-central-asia/README.MD
 Image: idiv-central-asia/thumbnail.png
-EDCBrowser: ""
 Resolution: 10m
 GeographicalCoverage: "(37.42°, 60.20°, 41.83°, 72.35°)"
 TemporalAvailability: "14 July 2008 - 25 June 2018"

--- a/collections/jaxa_wq_chla.yaml
+++ b/collections/jaxa_wq_chla.yaml
@@ -19,7 +19,6 @@ Description: |
   ```
 
 Image: jaxa_wq_chla/jaxa_wq_chla.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=10&lat=34.7&lng=136.9&collectionId=jaxa_wq_chla&layerId=Chlorophyll-a%20weekly%20anomaly&type=sentinel-hub-edc&fromTime=2021-03-03T15%3A37%3A51.349Z&toTime=2022-03-03T15%3A37%3A51.349Z 
 AdditionalInfoExternal:
     Title: Additional info
     Path: jaxa_wq_chla/README.MD

--- a/collections/jaxa_wq_chla_average.yaml
+++ b/collections/jaxa_wq_chla_average.yaml
@@ -17,7 +17,6 @@ Description: |
   ```
 Resolution: 0.0025 degrees equal lat lon
 Image: jaxa_wq_chla_average/jaxa_wq_chla_average.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=10&lat=34.7&lng=136.9&collectionId=jaxa_wq_chla_average&layerId=Chlorophyll-a%20weekly%20average&type=sentinel-hub-edc&fromTime=2021-03-03T15%3A37%3A15.909Z&toTime=2022-03-03T15%3A37%3A15.909Z
 GeographicalCoverage: |
    North Adriatic: lon E: 12.0 ~ 13.8, lat N: 44.5 ~ 45.8
    Tokyo: lon E: 139.25 ~ 140.25, lat N: 34.85 ~ 35.85

--- a/collections/jaxa_wq_tsm.yaml
+++ b/collections/jaxa_wq_tsm.yaml
@@ -16,7 +16,6 @@ Description: |
   dd:Day
   ```
 Image: jaxa_wq_tsm/jaxa_wq_tsm.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=10&lat=34.7&lng=136.9&collectionId=jaxa_wq_tsm&layerId=Total%20Suspended%20Matter%20weekly%20anomaly&type=sentinel-hub-edc&fromTime=2021-03-03T15%3A38%3A55.330Z&toTime=2022-03-03T15%3A38%3A55.330Z 
 AdditionalInfoExternal:
     Title: Additional info
     Path: jaxa_wq_tsm/README.MD

--- a/collections/jaxa_wq_tsm_average.yaml
+++ b/collections/jaxa_wq_tsm_average.yaml
@@ -17,7 +17,6 @@ Description: |
   ```
 Resolution: 0.0025 degrees equal lat lon
 Image: jaxa_wq_tsm_average/jaxa_wq_tsm_average.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=10&lat=34.7&lng=136.9&collectionId=jaxa_wq_tsm_average&layerId=Total%20suspended%20matter%20weekly%20average&type=sentinel-hub-edc&fromTime=2021-03-03T15%3A38%3A32.109Z&toTime=2022-03-03T15%3A38%3A32.109Z
 GeographicalCoverage: |
    North Adriatic: lon E: 12.0 ~ 13.8, lat N: 44.5 ~ 45.8
    Tokyo: lon E: 139.25 ~ 140.25, lat N: 34.85 ~ 35.85

--- a/collections/landsat-1-5-mss-l1.yaml
+++ b/collections/landsat-1-5-mss-l1.yaml
@@ -5,7 +5,6 @@ Description: |
  See [USGS EROS Archive](https://www.usgs.gov/centers/eros/science/usgs-eros-archive-landsat-archives-landsat-1-5-multispectral-scanner-collection?qt-science_center_objects=0#qt-science_center_objects) for more information. MSS Level-1 data provides Top of Atmosphere Reflectance products for the period from July 1972 to October 1992 and from June 2012 to January 2013.
 Documentation: "[here](https://docs.sentinel-hub.com/api/latest/data/landsat-mss/)"
 Image: landsat-1-5-mss-l1/landsat-1-5-mss-l1.png 
-EDCBrowser: https://browser.eurodatacube.com/?zoom=10&lat=41.75953&lng=11.90781&collectionId=LANDSAT1-5_MSS_L1&layerId=False%20Color%20Near%20Infrared&type=sentinel-hub-edc&fromTime=1993-08-05T00%3A00%3A00.000Z&toTime=1993-08-05T23%3A59%3A59.999Z
 EOBrowser: https://apps.sentinel-hub.com/eo-browser/?zoom=10&lat=41.9&lng=12.5&themeId=DEFAULT-THEME&visualizationUrl=https%3A%2F%2Fservices.sentinel-hub.com%2Fogc%2Fwms%2F88c5f9f6-0782-40aa-8cff-7c679520ed73&datasetId=AWS_LMSSL1&fromTime=1993-08-05T00%3A00%3A00.000Z&toTime=1993-08-05T23%3A59%3A59.999Z&layerId=FALSE-COLOR-NEAR-INFRARED
 Resolution: 68 m x 83 m (commonly resampled to 57 m, or 60 m)
 GeographicalCoverage: Global land

--- a/collections/landsat-4-5-tm-l1.yaml
+++ b/collections/landsat-4-5-tm-l1.yaml
@@ -7,7 +7,6 @@ Description: |
  for more information.
 Documentation: "[here](https://docs.sentinel-hub.com/api/latest/data/landsat-tm/#available-bands-and-data)"
 Image: landsat-4-5-tm-l1/landsat-4-5-tm-l1.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=10&lat=41.9&lng=12.5&collectionId=landsat-4-5-tm-l1&layerId=True%20color&type=sentinel-hub-edc&fromTime=2011-05-04T00%3A00%3A00.000Z&toTime=2012-05-04T00%3A00%3A00.000Z
 EOBrowser: https://apps.sentinel-hub.com/eo-browser/?zoom=11&lat=42.04904&lng=12.14264&themeId=DEFAULT-THEME&visualizationUrl=https%3A%2F%2Fservices.sentinel-hub.com%2Fogc%2Fwms%2F8da429bc-fefb-4c4a-b921-3c4b7effceec&datasetId=AWS_LTML1&fromTime=2011-11-11T00%3A00%3A00.000Z&toTime=2011-11-11T23%3A59%3A59.999Z&layerId=1_TRUE_COLOR
 Resolution: 30 m (the thermal band is re-sampled from 120 m)
 GeographicalCoverage: Global Land

--- a/collections/landsat-4-5-tm-l2.yaml
+++ b/collections/landsat-4-5-tm-l2.yaml
@@ -8,7 +8,6 @@ Description: |
  for more information.
 Documentation: "[here](https://docs.sentinel-hub.com/api/latest/data/landsat-tm-l2/)"
 Image: landsat-4-5-tm-l2/landsat-4-5-tm-l2.png 
-EDCBrowser: https://browser.eurodatacube.com/?zoom=10&lat=41.9&lng=12.5&collectionId=landsat-4-5-tm-l2&layerId=True%20color&type=sentinel-hub-edc&fromTime=2011-05-04T00%3A00%3A00.000Z&toTime=2012-05-04T00%3A00%3A00.000Z
 EOBrowser: https://apps.sentinel-hub.com/eo-browser/?zoom=11&lat=42.04904&lng=12.14264&themeId=DEFAULT-THEME&visualizationUrl=https%3A%2F%2Fservices.sentinel-hub.com%2Fogc%2Fwms%2F0cd456a8-dfef-400d-a340-b7448c4d7f03&datasetId=AWS_LTML2&fromTime=2011-11-11T00%3A00%3A00.000Z&toTime=2011-11-11T23%3A59%3A59.999Z&layerId=1_TRUE_COLOR
 Resolution: 30 m (the thermal band is re-sampled from 120 m)
 GeographicalCoverage: Global Land

--- a/collections/landsat-7-etm+-l1.yaml
+++ b/collections/landsat-7-etm+-l1.yaml
@@ -5,7 +5,6 @@ Description: |
  See [USGS EROS Archive](https://www.usgs.gov/centers/eros/science/usgs-eros-archive-landsat-archives-landsat-7-enhanced-thematic-mapper-plus?qt-science_center_objects=0#qt-science_center_objects) for more information. Landsat 7 Level-1 data provides Top of Atmosphere Reflectance and Top of the Atmosphere Brightness Temperature products. Level 1 data are available since April 1999. All scenes collected since May 30, 2003 have data gaps due to the Scan Line Corrector (SLC) failure.
 Documentation: "[here](https://docs.sentinel-hub.com/api/latest/data/landsat-etm/)"
 Image: landsat-7-etm+-l1/landsat-7-etm+-l1.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=10&lat=41.9&lng=12.5&collectionId=landsat-7-etm%2B-l1&layerId=True%20color&type=sentinel-hub-edc&fromTime=2021-05-01T16%3A03%3A38.591Z&toTime=2021-07-01T16%3A03%3A38.591Z
 EOBrowser: https://apps.sentinel-hub.com/eo-browser/?zoom=10&lat=41.87876&lng=12.40013&themeId=DEFAULT-THEME&visualizationUrl=https%3A%2F%2Fservices.sentinel-hub.com%2Fogc%2Fwms%2F74d0ab99-27a3-4bca-94ff-fbce3597372c&datasetId=AWS_LETML1&fromTime=2001-06-01T00%3A00%3A00.000Z&toTime=2001-06-16T23%3A59%3A59.999Z&layerId=1_TRUE_COLOR
 Resolution: 30 m (15 m for the panchromatic band, thermal band is re-sampled from 60 m)
 GeographicalCoverage: Global land

--- a/collections/landsat-7-etm+-l2.yaml
+++ b/collections/landsat-7-etm+-l2.yaml
@@ -5,7 +5,6 @@ Description: |
  See [USGS EROS Archive](https://www.usgs.gov/centers/eros/science/usgs-eros-archive-landsat-archives-landsat-7-etm-plus-collection-2-level-2?qt-science_center_objects=0#qt-science_center_objects) for more information. Landsat 7 level-2 data provides atmospherically corrected Surface Reflectance and Surface Brightness Temperature products. Level-2 data are available since April 1999.
 Documentation: "[here](https://docs.sentinel-hub.com/api/latest/data/landsat-etm-l2/)"
 Image: landsat-7-etm+-l2/landsat-7-etm+-l2.png 
-EDCBrowser: https://browser.eurodatacube.com/?zoom=10&lat=41.9&lng=12.5&collectionId=landsat-7-etm%2B-l2&layerId=True%20color&type=sentinel-hub-edc&fromTime=2021-03-04T16%3A06%3A33.574Z&toTime=2022-03-04T16%3A06%3A33.574Z
 EOBrowser: https://apps.sentinel-hub.com/eo-browser/?zoom=10&lat=41.87876&lng=12.40013&themeId=DEFAULT-THEME&visualizationUrl=https%3A%2F%2Fservices.sentinel-hub.com%2Fogc%2Fwms%2Fd752a452-0a29-42ba-97d8-29a1d49170f8&datasetId=AWS_LETML2&fromTime=2001-06-01T00%3A00%3A00.000Z&toTime=2001-06-16T23%3A59%3A59.999Z&layerId=1_TRUE_COLOR
 Resolution: 30 m (thermal band is re-sampled from 60 m)
 GeographicalCoverage: Global land

--- a/collections/landsat-8-l1.yaml
+++ b/collections/landsat-8-l1.yaml
@@ -10,7 +10,6 @@ Description: |
   provides Top of Atmosphere Reflectance and Top of the Atmosphere Brightness Temperature products. Level 1 data are available since February 2013 for Landsat 8 and since January 2022 for Landsat 9.
 Documentation: "[here](https://docs.sentinel-hub.com/api/latest/data/landsat-8/)"
 Image: landsat-8-l1/landsat-8-l1.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=10&lat=41.96442&lng=12.44594&collectionId=landsat-8-l1&layerId=True%20color&type=sentinel-hub-edc&fromTime=2012-07-03T16%3A08%3A30.217Z&toTime=2019-01-01T16%3A08%3A30.217Z 
 EOBrowser: https://apps.sentinel-hub.com/eo-browser/?zoom=12&lat=45.66157&lng=12.77023&themeId=DEFAULT-THEME&visualizationUrl=https%3A%2F%2Fservices.sentinel-hub.com%2Fogc%2Fwms%2Fe35192fe-33a1-41f3-b798-b755e771c5a5&datasetId=AWS_LOTL1&fromTime=2021-03-02T00%3A00%3A00.000Z&toTime=2021-03-02T23%3A59%3A59.999Z&layerId=1_TRUE_COLOR
 Resolution: 30m
 GeographicalCoverage: Land ([more info](https://landsat.gsfc.nasa.gov/landsat-8/mission-details))

--- a/collections/landsat-8-l2.yaml
+++ b/collections/landsat-8-l2.yaml
@@ -11,7 +11,6 @@ Description: |
   Collection 2 level 2 data are available since February 2013 for Landsat 8 and since January 2022 for Landsat 9 and new data are continously added usually within 24 hours after Level 1 scenes are available.
 Documentation: "[here](https://docs.sentinel-hub.com/api/latest/data/landsat-8-l2/)"
 Image: landsat-8-l2/landsat-8-l2.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=12&lat=41.88454&lng=12.40628&collectionId=landsat-8-l2&layerId=True%20color&type=sentinel-hub-edc&fromTime=2012-07-01T08%3A43%3A10.672Z&toTime=2013-08-05T08%3A43%3A10.672Z 
 EOBrowser: https://apps.sentinel-hub.com/eo-browser/?zoom=12&lat=45.66157&lng=12.77023&themeId=DEFAULT-THEME&visualizationUrl=https%3A%2F%2Fservices.sentinel-hub.com%2Fogc%2Fwms%2Ffa073661-b70d-4b16-a6a9-e866825f05fd&datasetId=AWS_LOTL2&fromTime=2021-03-02T00%3A00%3A00.000Z&toTime=2021-03-02T23%3A59%3A59.999Z&layerId=1_TRUE_COLOR
 Resolution: 30m
 GeographicalCoverage: Land ([more info](https://landsat.gsfc.nasa.gov/landsat-8/mission-details))

--- a/collections/mapzen-dem.yaml
+++ b/collections/mapzen-dem.yaml
@@ -9,7 +9,6 @@ Description: |
   Mapzen DEM provides bare-earth terrain heights and can also be used for the orthorectification of satellite imagery (e.g Sentinel 1).
 Documentation: "[here](https://docs.sentinel-hub.com/api/latest/data/dem/)"
 Image: mapzen-dem/mapzen-dem.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=10&lat=41.9&lng=12.5&collectionId=mapzen-dem&layerId=Color&type=sentinel-hub-edc&fromTime=2021-03-04T16%3A12%3A38.129Z&toTime=2022-03-04T16%3A12%3A38.129Z
 EOBrowser: https://apps.sentinel-hub.com/eo-browser/?zoom=10&lat=41.9&lng=12.5&themeId=DEFAULT-THEME&visualizationUrl=https%3A%2F%2Fservices.sentinel-hub.com%2Fogc%2Fwms%2F7ffc45f2-61f3-4c4d-b7eb-13cce1633d81&datasetId=DEM_MAPZEN&fromTime=2021-04-08T00%3A00%3A00.000Z&toTime=2021-04-08T23%3A59%3A59.999Z&layerId=COLOR
 Resolution: "varies per zoom level, location and data source [more info](https://github.com/tilezen/joerd/blob/master/docs/data-sources.md#what-is-the-ground-resolution)"
 GeographicalCoverage: Ocean and Land ([more info](https://github.com/tilezen/joerd/blob/master/docs/data-sources.md#footprints-database))

--- a/collections/microsoft-floods-s1.yaml
+++ b/collections/microsoft-floods-s1.yaml
@@ -6,7 +6,6 @@ AdditionalInfoExternal:
   Title: Additional info
   Path: microsoft-floods-s1/README.MD
 Image: microsoft-floods-s1/thumbnail.png
-EDCBrowser: ""
 Resolution: 10m
 GeographicalCoverage: "(-96.63°, -25.25°, 141.12°, 48.75°)"
 TemporalAvailability: "12 August 2016 - 20 October 2020"

--- a/collections/microsoft-floods-s2.yaml
+++ b/collections/microsoft-floods-s2.yaml
@@ -6,7 +6,6 @@ AdditionalInfoExternal:
   Title: Additional info
   Path: microsoft-floods-s2/README.MD
 Image: microsoft-floods-s2/thumbnail.png
-EDCBrowser: ""
 Resolution: 10m
 GeographicalCoverage: "(-96.63°, -25.25°, 141.12°, 48.75°)"
 TemporalAvailability: "12 August 2016 - 20 October 2020"

--- a/collections/modis.yaml
+++ b/collections/modis.yaml
@@ -11,7 +11,6 @@ Description: |
  MCD43A4.006 is available since February 2000 on a daily basis but with a 8 days delay. Sentinel Hub no longer has the latest MODIS data because the underlying data provider has ceased operations. Data from February 24, 2000 to February 10, 2023 remains accessible.
 Documentation: "[here](https://docs.sentinel-hub.com/api/latest/data/modis/mcd/)"
 Image: modis/modis.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=10&lat=41.9&lng=12.5&collectionId=modis&layerId=True%20Color&type=sentinel-hub-edc&fromTime=2021-03-04T16%3A13%3A10.878Z&toTime=2022-03-04T16%3A13%3A10.878Z
 EOBrowser: https://apps.sentinel-hub.com/eo-browser/?zoom=10&lat=41.9&lng=12.5&themeId=DEFAULT-THEME&datasetId=MODIS&fromTime=2021-03-29T00:00:00.000Z&toTime=2021-03-29T23:59:59.999Z&layerId=1-TRUE-COLOR&visualizationUrl=https://services.sentinel-hub.com/ogc/wms/a322e0b3-0652-4c62-8dde-404781863e5f
 Resolution: 500m
 GeographicalCoverage: MCD43A4.006 product covers Land ([more info](https://modis.gsfc.nasa.gov/about/specifications.php))

--- a/collections/nhrl.yaml
+++ b/collections/nhrl.yaml
@@ -8,7 +8,6 @@ AdditionalInfoExternal:
   Title: Additional info
   Path: nhrl/README.MD
 Image: nhrl/thumbnail.png
-EDCBrowser: "https://browser.eurodatacube.com/?zoom=12&lat=47.48299&lng=19.04274&collectionId=LTK_NATIONAL_HIGH_RESOLUTION_LAYER&layerId=NHRL%20Land%20Cover&type=sentinel-hub-edc&fromTime=2020-01-01T00%3A00%3A00.000Z&toTime=2021-01-01T00%3A00%3A00.000Z"
 Resolution: 10m
 GeographicalCoverage: "Hungary (16.0°, 45.0°, 23.0°, 49.0°)"
 TemporalAvailability: "2016 -2021"

--- a/collections/phytoplankton-primary-production.yaml
+++ b/collections/phytoplankton-primary-production.yaml
@@ -5,7 +5,6 @@ AdditionalInfoExternal:
   Title: Additional info
   Path: phytoplankton-primary-production/README.MD
 Image: phytoplankton-primary-production/npp.png
-EDCBrowser: ""
 Resolution: gridded 9 Km spatial resolution
 GeographicalCoverage: -180.0, -90.0, 180.0, 90.0
 TemporalAvailability: 1998 - 2020

--- a/collections/plantvillage-crops-kenya.yaml
+++ b/collections/plantvillage-crops-kenya.yaml
@@ -5,7 +5,6 @@ AdditionalInfoExternal:
   Title: Additional info
   Path: plantvillage-crops-kenya/README.MD
 Image: plantvillage-crops-kenya/thumbnail.png
-EDCBrowser: ""
 Resolution: 10m
 GeographicalCoverage: "(34.18°, 0.47°, 34.38°, 0.72°)"
 TemporalAvailability: "14 May 2019 - 03 June 2019"

--- a/collections/pni.yaml
+++ b/collections/pni.yaml
@@ -3,7 +3,6 @@ Name: Percent of Normal Index (PNI)
 Description: Percent of Normal Index (PNI) is calculated by dividing actual precipitation (for the previous 30 or 90 days) by normal precipitation for the time being considered (1991-2020) and multiplying by 100.
 Documentation: "[Climate Indices](https://climate-indices.readthedocs.io/en/latest/#), [Percentage of Normal Precipitation](https://www.droughtmanagement.info/percent-of-normal-precipitation/)"
 Image: pni/thumbnail.png
-#EDCBrowser: "https://browser.eurodatacube.com/?zoom=8&lat=47.13454&lng=18.75696&collectionId=LTK_Percent_of_Normal_Index&layerId=Percent%20of%20Normal%20Index&type=sentinel-hub-edc&fromTime=2022-08-01T00%3A00%3A00.000Z&toTime=2022-08-01T23%3A59%3A59.999Z"
 Resolution: "0.11°"
 GeographicalCoverage: "Hungary (16.0°, 45.0°, 23.0°, 49.0°)"
 TemporalAvailability: "1971-01-01 - Ongoing"

--- a/collections/population_density.yaml
+++ b/collections/population_density.yaml
@@ -5,7 +5,6 @@ AdditionalInfoExternal:
     Title: Additional info
     Path: population_density/README.MD
 Image: population_density/population_density.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=3&lat=21.89208&lng=-48.28697&collectionId=population_density&layerId=Population%20Density&type=sentinel-hub-edc&fromTime=2019-12-31T23%3A59%3A59.000Z&toTime=2020-12-31T23%3A59%3A59.000Z
 Resolution: 1000m
 GeographicalCoverage: -180.0, -90.0, 179.99999999999983, 89.99999999999991
 TemporalAvailability: "2020-05-01"

--- a/collections/s5p-ch4-weekly.yaml
+++ b/collections/s5p-ch4-weekly.yaml
@@ -8,7 +8,6 @@ AdditionalInfoExternal:
   Title: Additional info
   Path: s5p-ch4-weekly/README.MD
 Image: s5p-ch4-weekly/ch4.PNG
-EDCBrowser: https://browser.eurodatacube.com/?zoom=7&lat=38.80975&lng=-8.18481&collectionId=SENTINEL_5P_CH4_T7D_AVERAGE&layerId=CH4-weekly&type=sentinel-hub-edc&fromTime=2023-07-24T00%3A00%3A00.000Z&toTime=2023-07-24T23%3A59%3A59.999Z
 Resolution: 4.8 x 4.8 Km (across x along track)
 GeographicalCoverage: -180.0, -90.0, 180.0, 90.0
 TemporalAvailability: 2021-11-15 - ongoing

--- a/collections/s5p-no2-tropno-daily-check.yaml
+++ b/collections/s5p-no2-tropno-daily-check.yaml
@@ -5,7 +5,6 @@ AdditionalInfoExternal:
     Title: Additional info
     Path: s5p-no2-tropno-daily-check/README.MD
 Image: s5p-no2-tropno-daily-check/s5p-no2-tropno-daily-check.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=5&lat=50.44351&lng=-5.75684&collectionId=s5p-no2-tropno-daily-check&layerId=NO2&type=sentinel-hub-edc&fromTime=2021-03-08T09%3A44%3A48.897Z&toTime=2022-03-08T09%3A44%3A48.897Z
 Resolution: 3.5 x 5.5 Km (across x along track)
 GeographicalCoverage: -180.0, -90.0, 180.0, 90.0
 TemporalAvailability: 2018-04-30 - ongoing

--- a/collections/sentinel-1-grd.yaml
+++ b/collections/sentinel-1-grd.yaml
@@ -11,7 +11,6 @@ Description:
 Documentation: "[here](https://docs.sentinel-hub.com/api/latest/data/sentinel-1-grd/)"
 Image: sentinel-1-grd/sentinel-1-grd.png
 Resolution: High - 10m, Medium - 40m
-EDCBrowser: https://browser.eurodatacube.com/?zoom=10&lat=41.9&lng=12.5&collectionId=sentinel-1-grd&layerId=SAR%20urban&type=sentinel-hub-edc&fromTime=2021-03-04T16%3A39%3A33.381Z&toTime=2022-03-04T16%3A39%3A33.381Z
 EOBrowser: https://apps.sentinel-hub.com/eo-browser/?zoom=10&lat=41.9&lng=12.5&themeId=DEFAULT-THEME&visualizationUrl=https%3A%2F%2Fservices.sentinel-hub.com%2Fogc%2Fwms%2Ff2068f4f-3c75-42cf-84a1-42948340a846&datasetId=S1_AWS_IW_VVVH&fromTime=2021-03-28T00%3A00%3A00.000Z&toTime=2021-03-28T23%3A59%3A59.999Z&layerId=ENHANCED-VISUALIZATION-ORTHORECTIFIED
 Explore: "[Open Notebook](https://eurodatacube.com/marketplace/notebooks/contributions/Exploring_time_and_space_with_EDC.ipynb)"
 GeographicalCoverage: Land, coastal zones, shipping routes ([more info](https://sentinel.esa.int/web/sentinel/user-guides/sentinel-1-sar/revisit-and-coverage))

--- a/collections/sentinel-2-l1c.yaml
+++ b/collections/sentinel-2-l1c.yaml
@@ -9,7 +9,6 @@ Description: |
   June 2015 globally. L1C data provide Top of the atmosphere (TOA) reflectance.
 Image: sentinel-2-l1c/sentinel-2-l1c.png
 Documentation: "[here](https://docs.sentinel-hub.com/api/latest/data/sentinel-2-l1c/)"
-EDCBrowser: https://browser.eurodatacube.com/?zoom=11&lat=41.91326&lng=12.41386&collectionId=sentinel-2-l1c&layerId=True%20Color&type=sentinel-hub-edc&fromTime=2020-03-08T09%3A57%3A46.781Z&toTime=2021-08-01T09%3A57%3A46.781Z
 EOBrowser: https://apps.sentinel-hub.com/eo-browser/?zoom=10&lat=41.9&lng=12.5&themeId=DEFAULT-THEME&datasetId=S2L1C&fromTime=2021-03-31T00:00:00.000Z&toTime=2021-03-31T23:59:59.999Z&layerId=1_TRUE_COLOR&visualizationUrl=https://services.sentinel-hub.com/ogc/wms/42924c6c-257a-4d04-9b8e-36387513a99c
 Resolution: 10m
 GeographicalCoverage: Land surface area ([more info](https://sentinel.esa.int/web/sentinel/user-guides/sentinel-2-msi/revisit-coverage))

--- a/collections/sentinel-2-l2a.yaml
+++ b/collections/sentinel-2-l2a.yaml
@@ -9,7 +9,6 @@ Description: |
   region and globally since January 2017. L2A data provide Bottom of the atmosphere (BOA) reflectance.
 Documentation: "[here](https://docs.sentinel-hub.com/api/latest/data/sentinel-2-l2a/)"
 Image: sentinel-2-l2a/sentinel-2-l2a.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=11&lat=41.91326&lng=12.41386&collectionId=sentinel-2-l2a&layerId=True%20Color&type=sentinel-hub-edc&fromTime=2020-03-08T10%3A00%3A37.159Z&toTime=2021-08-01T10%3A00%3A37.159Z
 EOBrowser: https://apps.sentinel-hub.com/eo-browser/?zoom=10&lat=41.9&lng=12.5&themeId=DEFAULT-THEME&visualizationUrl=https%3A%2F%2Fservices.sentinel-hub.com%2Fogc%2Fwms%2Fbd86bcc0-f318-402b-a145-015f85b9427e&datasetId=S2L2A&fromTime=2021-03-31T00%3A00%3A00.000Z&toTime=2021-03-31T23%3A59%3A59.999Z&layerId=1_TRUE_COLOR
 Resolution: 10m
 GeographicalCoverage: Land surface area ([more info](https://sentinel.esa.int/web/sentinel/user-guides/sentinel-2-msi/revisit-coverage))

--- a/collections/sentinel-s2-l2a-mosaic-120.yaml
+++ b/collections/sentinel-s2-l2a-mosaic-120.yaml
@@ -10,7 +10,6 @@ AdditionalInfoExternal:
     Title: Additional info
     Path: sentinel-s2-l2a-mosaic-120/README.MD
 Image: sentinel-s2-l2a-mosaic-120/sentinel-s2-l2a-mosaic-120.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=10&lat=41.9&lng=12.5&collectionId=sentinel-s2-l2a-mosaic-120&layerId=True%20Color&type=sentinel-hub-edc&fromTime=2019-12-31T00%3A00%3A00.000Z&toTime=2020-12-31T00%3A00%3A00.000Z
 Resolution: 120m
 GeographicalCoverage: Land surface area between 58 degrees South and 72 degrees North.
 TemporalAvailability: 2020 (past years will be added later); old 2019 data results can be found [here](https://collections.eurodatacube.com/sentinel-s2-l2a-mosaic-120/sentinel-2-l2a-120m-mosaic-2019.html).

--- a/collections/so2_daily_data.yaml
+++ b/collections/so2_daily_data.yaml
@@ -6,7 +6,6 @@ AdditionalInfoExternal:
   Title: Additional info
   Path: so2_daily_data/README.MD
 Image: so2_daily_data/so2.png
-EDCBrowser: ""
 Resolution: 4.8 x 4.8 Km (across x along track). The measurements are then mapped on a fixed latitude-longitude grid of 8193 x 16385 pixels. The grid is turned into an EPSG:4326 geotiff file using the appropriate color scale, which is again turned into an EPSG:3857 tile map.
 GeographicalCoverage: -180.0, -90.0, 180.0, 90.0
 TemporalAvailability: 2021-09-19 - ongoing

--- a/collections/south-africa-crops-competition.yaml
+++ b/collections/south-africa-crops-competition.yaml
@@ -5,7 +5,6 @@ AdditionalInfoExternal:
   Title: Additional info
   Path: south-africa-crops-competition/README.MD
 Image: south-africa-crops-competition/thumbnail.png
-EDCBrowser: ""
 Resolution: 10m
 GeographicalCoverage: "(17.81°, -34.16°, 19.77°, -30.75°)"
 TemporalAvailability: "1 August 2017"

--- a/collections/spei.yaml
+++ b/collections/spei.yaml
@@ -3,7 +3,6 @@ Name: Standard Precipitation Evapotranspiration Index (SPEI)
 Description: Standard Precipitation Evapotranspiration Index (SPEI) uses the basis of [Standard Precipitation Index](https://collections.eurodatacube.com/spi/) but includes a temperature component, allowing the index to account for the effect of temperature on drought development through a basic water balance calculation.
 Documentation: "[Climate Indices](https://climate-indices.readthedocs.io/en/latest/#), [SPEI](https://climatedataguide.ucar.edu/climate-data/standardized-precipitation-evapotranspiration-index-spei)"
 Image: spei/thumbnail.png
-#EDCBrowser: "https://browser.eurodatacube.com/?zoom=8&lat=47.13454&lng=18.75696&collectionId=LTK_Standard_Precipitation_Evapotranspiration_Index&layerId=Standard%20Precipitation%20Evapotranspiration%20Index&type=sentinel-hub-edc&fromTime=2022-07-31T22%3A00%3A00.000Z&toTime=2022-08-01T21%3A59%3A59.999Z"
 Resolution: "0.11°"
 GeographicalCoverage: "Hungary (16.0°, 45.0°, 23.0°, 49.0°)"
 TemporalAvailability: "1971-01-01 - Ongoing"

--- a/collections/spi.yaml
+++ b/collections/spi.yaml
@@ -3,7 +3,6 @@ Name: Standard Precipitation Index (SPI)
 Description: Standard Precipitation Index (SPI) quantifies observed precipitation as a standardized departure from a selected probability distribution function that models the raw precipitation data. The raw precipitation data are typically fitted to a gamma or a Pearson Type III distribution, and then transformed to a normal distribution.
 Documentation: "[Climate Indices](https://climate-indices.readthedocs.io/en/latest/#), [SPI](https://climatedataguide.ucar.edu/climate-data/standardized-precipitation-index-spi)"
 Image: spi/thumbnail.png
-#EDCBrowser: "https://browser.eurodatacube.com/?zoom=8&lat=47.13414&lng=18.75916&collectionId=LTK_Standard_Precipitation_Index&layerId=Standard%20Precipitation%20Index&type=sentinel-hub-edc&fromTime=2022-09-01T00%3A00%3A00.000Z&toTime=2022-09-01T23%3A59%3A59.999Z"
 Resolution: "0.11°"
 GeographicalCoverage: "Hungary (16.0°, 45.0°, 23.0°, 49.0°)"
 TemporalAvailability: "1971-01-01 -Ongoing"

--- a/collections/tsmn_water_quality_saturday.yaml
+++ b/collections/tsmn_water_quality_saturday.yaml
@@ -5,7 +5,6 @@ AdditionalInfoExternal:
     Title: Additional info
     Path: tsmn_water_quality_saturday/README.MD
 Image: tsmn_water_quality_saturday/tsmn_water_quality_saturday.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=7&lat=43.14975&lng=7.16013&collectionId=tsmn_water_quality_saturday&layerId=Total%20Suspended%20Matter%20Map&type=sentinel-hub-edc&fromTime=2020-04-17T00%3A00%3A00.000Z&toTime=2021-04-17T00%3A00%3A00.000Z
 Resolution: 300m
 GeographicalCoverage: 0.4982046708598385, 40.498973093940286, 13.82206392288208, 45.80052375793457
 TemporalAvailability: 2020-01-04 - ongoing

--- a/collections/vessel_density_all.yaml
+++ b/collections/vessel_density_all.yaml
@@ -7,7 +7,6 @@ AdditionalInfoExternal:
   Title: Additional info
   Path: vessel_density_all/README.md
 Image: vessel_density_all/vessel_density_all.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=3&lat=46.25585&lng=3.69141&collectionId=EMODNET_VESSEL_DENSITY&layerId=vessel_density_all&type=sentinel-hub-edc&fromTime=2020-12-01T00%3A00%3A00.000Z&toTime=2020-12-01T23%3A59%3A59.999Z
 Resolution: 0.0083 x 0.0083°
 GeographicalCoverage: -66.949482215, 19.222315519, 72.48195026, 74.653019863
 TemporalAvailability: 2017-01-01 - 2020-12-01

--- a/collections/vessel_density_cargo.yaml
+++ b/collections/vessel_density_cargo.yaml
@@ -17,7 +17,6 @@ AdditionalInfoExternal:
   Title: Additional info
   Path: vessel_density_cargo/README.md
 Image: vessel_density_cargo/vessel_density_cargo.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=3&lat=46.25585&lng=3.69141&collectionId=EMODNET_VESSEL_DENSITY_CARGO&layerId=vessel_density_cargo&type=sentinel-hub-edc&fromTime=2020-12-01T00%3A00%3A00.000Z&toTime=2020-12-01T23%3A59%3A59.999Z
 Resolution: 0.0083 x 0.0083°
 GeographicalCoverage: -66.949482215, 19.222315519, 72.48195026, 74.653019863
 TemporalAvailability: 2017-01-01 - 2020-12-01

--- a/collections/vessel_density_other.yaml
+++ b/collections/vessel_density_other.yaml
@@ -7,7 +7,6 @@ AdditionalInfoExternal:
   Title: Additional info
   Path: vessel_density_other/README.md
 Image: vessel_density_other/vessel_density_other.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=7&lat=36.52288&lng=-7.31689&collectionId=EMODNET_VESSEL_DENSITY_OTHER&layerId=vessel_density_other&type=sentinel-hub-edc&fromTime=2020-12-01T00%3A00%3A00.000Z&toTime=2020-12-01T23%3A59%3A59.999Z
 Resolution: 0.0083 x 0.0083°
 GeographicalCoverage: -66.949482215, 19.222315519, 72.48195026, 74.653019863
 TemporalAvailability: 2017-01-01 - 2020-12-01

--- a/collections/vessel_density_tanker.yaml
+++ b/collections/vessel_density_tanker.yaml
@@ -17,7 +17,6 @@ AdditionalInfoExternal:
   Title: Additional info
   Path: vessel_density_tanker/README.md
 Image: vessel_density_tanker/vessel_density_tanker.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=8&lat=50.59544&lng=0.39551&collectionId=EMODNET_VESSEL_DENSITY_TANKER&layerId=vessel_density_tanker&type=sentinel-hub-edc&fromTime=2020-12-01T00%3A00%3A00.000Z&toTime=2020-12-01T23%3A59%3A59.999Z
 Resolution: 0.0083 x 0.0083°
 GeographicalCoverage: -66.949482215, 19.222315519, 72.48195026, 74.653019863
 TemporalAvailability: 2017-01-01 - 2020-12-01

--- a/collections/western-usa-fuel-moisture.yaml
+++ b/collections/western-usa-fuel-moisture.yaml
@@ -5,7 +5,6 @@ AdditionalInfoExternal:
   Title: Additional info
   Path: western-usa-fuel-moisture/README.MD
 Image: "western-usa-fuel-moisture/thumbnail.png"
-EDCBrowser: ""
 Resolution: 10m
 GeographicalCoverage: "(-123.53°, 28.30°, -93.73°, 48.50°)"
 TemporalAvailability: "30 June 2015 - 31 January 2019"

--- a/collections/wind_10m_u.yaml
+++ b/collections/wind_10m_u.yaml
@@ -5,7 +5,6 @@ AdditionalInfoExternal:
     Title: Additional info
     Path: wind_10m_u/README.MD
 Image: wind_10m_u/wind_10m_u.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=1&lat=0.00005&lng=0.00001&collectionId=wind_10m_u&layerId=Wind%20U-component&type=sentinel-hub-edc&fromTime=2019-12-01T00%3A00%3A00.000Z&toTime=2020-12-01T00%3A00%3A00.000Z
 Resolution: 0.25° x 0.25°
 GeographicalCoverage: -179.999755859375, -90.12489004526765, 179.99977453631897, 90.125
 TemporalAvailability: 2019-01-01 - 2022-04-01

--- a/collections/wind_10m_v.yaml
+++ b/collections/wind_10m_v.yaml
@@ -5,7 +5,6 @@ AdditionalInfoExternal:
     Title: Additional info
     Path: wind_10m_v/README.MD
 Image: wind_10m_v/wind_10m_v.png
-EDCBrowser: https://browser.eurodatacube.com/?zoom=1&lat=0.00005&lng=0.00001&collectionId=wind_10m_v&layerId=Wind%20V-component&type=sentinel-hub-edc&fromTime=2019-12-01T00%3A00%3A00.000Z&toTime=2020-12-01T00%3A00%3A00.000Z
 Resolution: 0.25° x 0.25°
 GeographicalCoverage: -179.999755859375, -90.12489004526765, 179.99977453631897, 90.125
 TemporalAvailability: 2019-01-01 - 2022-04-01

--- a/collections/worldcover.yaml
+++ b/collections/worldcover.yaml
@@ -9,7 +9,6 @@ Description: |
 AdditionalInfoExternal:
     Title: Additional info
     Path: worldcover/README.MD
-EDCBrowser: https://browser.eurodatacube.com/?zoom=10&lat=41.91823&lng=12.492&collectionId=worldcover&layerId=ESA%20WorldCover%20Map&type=sentinel-hub-edc&fromTime=2020-01-01T00%3A00%3A00.000Z&toTime=2020-01-01T23%3A59%3A59.999Z
 EOBrowser: https://apps.sentinel-hub.com/eo-browser/?zoom=10&lat=41.9&lng=12.5&themeId=DEFAULT-THEME&visualizationUrl=https%3A%2F%2Fservices.sentinel-hub.com%2Fogc%2Fwms%2F8a1d5370-99f2-404f-a65f-22424762237b&datasetId=COPERNICUS_WORLD_COVER&fromTime=2020-01-01T00%3A00%3A00.000Z&toTime=2020-01-01T23%3A59%3A59.999Z&layerId=WORLDCOVER-MAP
 Image: worldcover/thumbnail.png
 Resolution: 10m


### PR DESCRIPTION
- removed EDC Browser links in yaml files
- removed code for generating "open in EDC Browser" button

Remaining EDC Browser links are in the instructions for how to run algorithms (as part of "bring your own algorithm") and are kept because a new procedure should be defined first.